### PR TITLE
fix: handle max width up to 5000px

### DIFF
--- a/packages/gatsby-transformer-cloudinary/get-image-objects.js
+++ b/packages/gatsby-transformer-cloudinary/get-image-objects.js
@@ -171,7 +171,14 @@ exports.getFluidImageObject = async ({
     chained,
   });
 
-  const srcSet = breakpoints
+  const cleaned = breakpoints
+    .concat(max) // make sure we get the max size
+    .filter(w => w <= max) // don’t add larger sizes
+    .sort((a, b) => a - b); // sort in ascending order
+
+  const deduped = [...new Set(cleaned)];
+
+  const srcSet = deduped
     .map(breakpointWidth => {
       // Get URL for each image including user-defined transformations.
       const url = getImageURL({

--- a/packages/gatsby-transformer-cloudinary/upload.js
+++ b/packages/gatsby-transformer-cloudinary/upload.js
@@ -1,6 +1,6 @@
 const cloudinary = require('cloudinary').v2;
 
-const DEFAULT_FLUID_MAX_WIDTH = 650;
+const DEFAULT_FLUID_MAX_WIDTH = 5000;
 const DEFAULT_FLUID_MIN_WIDTH = 200;
 
 exports.uploadImageNodeToCloudinary = async (node, options) => {


### PR DESCRIPTION
Using the breakpoints generated by Cloudinary means we can’t access query arguments, so instead we can just get a huge set of breakpoints and filter to just the ones we need.

fix #5