### PR TITLE
add ${__dirname} to path config

### DIFF
--- a/packages/gatsby-transformer-cloudinary/README.md
+++ b/packages/gatsby-transformer-cloudinary/README.md
@@ -49,7 +49,7 @@ module.exports = {
       resolve: `gatsby-source-filesystem`,
       options: {
         name: `images`,
-        path: `src/images`,
+        path: `${__dirname}/src/images`,
       },
     },
     {


### PR DESCRIPTION
I was getting a path error.  Using `path: `${__dirname}/src/images`,` resolved it for me