### PR TITLE
[IMPORTANT]: fix bug in uploading large/multiple images

### DIFF
--- a/packages/gatsby-transformer-cloudinary/upload.js
+++ b/packages/gatsby-transformer-cloudinary/upload.js
@@ -1,28 +1,33 @@
 const cloudinary = require('cloudinary').v2;
 
-const DEFAULT_FLUID_MAX_WIDTH = 5000;
+const DEFAULT_FLUID_MAX_WIDTH = 1000;
 const DEFAULT_FLUID_MIN_WIDTH = 200;
 
 exports.uploadImageNodeToCloudinary = async (node, options) => {
+  const {cloudName, apiKey, apiSecret, uploadFolder, fluidMaxWidth = DEFAULT_FLUID_MAX_WIDTH, fluidMinWidth = DEFAULT_FLUID_MIN_WIDTH, breakpointsMaxImages = 5, createDerived = true} =  options;
   cloudinary.config({
-    cloud_name: options.cloudName,
-    api_key: options.apiKey,
-    api_secret: options.apiSecret,
+    cloud_name: cloudName,
+    api_key: apiKey,
+    api_secret: apiSecret,
   });
 
-  const result = await cloudinary.uploader.upload(node.absolutePath, {
-    folder: options.uploadFolder,
-    public_id: node.name,
-    responsive_breakpoints: [
-      {
-        create_derived: true,
-        bytes_step: 20000,
-        min_width: DEFAULT_FLUID_MIN_WIDTH,
-        max_width: DEFAULT_FLUID_MAX_WIDTH,
-        max_images: 20,
-      },
-    ],
-  });
-
-  return result;
+  try{
+    const result = await cloudinary.uploader.upload(node.absolutePath, {
+      folder: uploadFolder,
+      public_id: node.name,
+      resource_type: 'auto',
+      responsive_breakpoints: [
+        {
+          create_derived: createDerived,
+          bytes_step: 20000,
+          min_width: fluidMinWidth,
+          max_width: fluidMaxWidth,
+          max_images: breakpointsMaxImages,
+        },
+      ],
+    });
+    return result;
+  }catch(e){
+    throw e;
+  }
 };


### PR DESCRIPTION
Fixed the bug with uploading multiple images. The issue was in the responsive breakpoint limit set when uploading to Cloudinary and receiving derived Images.
Also, set defaults for required upload config, with the option for a user to specify in `gatsby-config`. 

todo: update Readme with config options. 

Should close #18 #17 #15 #11 