### PR TITLE
added sourceInstanceName option to plugin configuration

### DIFF
--- a/packages/gatsby-transformer-cloudinary/README.md
+++ b/packages/gatsby-transformer-cloudinary/README.md
@@ -117,7 +117,8 @@ In `gatsby-config.js` the plugin accepts the following options:
 | `fluidMinWidth`        | `Int`     | false    | 200           | Min width set for responsive breakpoints images generated and returned on image upload.                                                                                                 |
 | `createDerived`        | `Boolean` | false    | true          | This option is specifies the creation of derived images using the specified fluidMinWidth and fluidMaxWidth dimensions specified.                                                       |
 | `breakpointsMaxImages` | `Integer` | false    | 5             | Set maximum number of responsive breakpoint images generated and returned on image upload.                                                                                              |
-
+| `sourceInstanceName`   | `String`  | false    | n/a           | Source instance name to be used while transforming images. This option should have the same value which is used by `gatsby-source-filesystem` plugin in options.name property.          |
+  
 > Note: Setting a high max width such as 5000 will lead to the generation of a lot of derived images, between the max and min widths breakpoints on image upload. Use this option with care.
 
 

--- a/packages/gatsby-transformer-cloudinary/gatsby-node.js
+++ b/packages/gatsby-transformer-cloudinary/gatsby-node.js
@@ -133,6 +133,13 @@ exports.onCreateNode = async (
   { node, actions, reporter, createNodeId },
   options,
 ) => {
+  // Transform only those images specified by 'sourceInstanceName' option.
+  if (
+    options.sourceInstanceName &&
+    options.sourceInstanceName !== node.sourceInstanceName) {
+    return;
+  }
+
   if (!ALLOWED_MEDIA_TYPES.includes(node.internal.mediaType)) {
     return;
   }


### PR DESCRIPTION
Currently, when we use this plugin, all images are being uploaded to the cloudinary. In some use cases we want to have only some of them uploaded and transformed by cloudinary. In others, we might want to migrate our code gradually,

With this change we can specify separate directory for our cloudinary images and create new gatsby-source-filesystem` name for them. Then we can process only those images by adding:

```
sourceInstanceName: 'cloudinary-images'
```

to our plugin configuration.