### PR TITLE
Add configurable public_id

### DIFF
--- a/packages/gatsby-transformer-cloudinary/README.md
+++ b/packages/gatsby-transformer-cloudinary/README.md
@@ -116,7 +116,8 @@ In `gatsby-config.js` the plugin accepts the following options:
 | `fluidMaxWidth`        | `Int`     | false    | 1000          | Max width set for responsive breakpoints images generated and returned on image upload.                                                                                                 |
 | `fluidMinWidth`        | `Int`     | false    | 200           | Min width set for responsive breakpoints images generated and returned on image upload.                                                                                                 |
 | `createDerived`        | `Boolean` | false    | true          | This option is specifies the creation of derived images using the specified fluidMinWidth and fluidMaxWidth dimensions specified.                                                       |
-| `breakpointsMaxImages` | `Integer` | false    | 5             | Set maximum number of responsive breakpoint images generated and returned on image upload.                                                                                              |
+| `breakpointsMaxImages` | `Integer` | false    | 5             | Set maximum number of responsive breakpoint images generated and returned on image upload. 
+| `publicId` | `Function` | false    | `node.name`             | This functions accepts a File node and returns the public_id that will be used in the upload.
 
 > Note: Setting a high max width such as 5000 will lead to the generation of a lot of derived images, between the max and min widths breakpoints on image upload. Use this option with care.
 

--- a/packages/gatsby-transformer-cloudinary/fragments.js
+++ b/packages/gatsby-transformer-cloudinary/fragments.js
@@ -10,9 +10,27 @@ export const cloudinaryAssetFluid = graphql`
   }
 `;
 
+export const cloudinaryAssetFluid_noBase64 = graphql`
+  fragment CloudinaryAssetFluid_noBase64 on CloudinaryAssetFluid {
+    aspectRatio
+    sizes
+    src
+    srcSet
+  }
+`;
+
 export const cloudinaryAssetFixed = graphql`
   fragment CloudinaryAssetFixed on CloudinaryAssetFixed {
     base64
+    height
+    src
+    srcSet
+    width
+  }
+`;
+
+export const cloudinaryAssetFixed_noBase64 = graphql`
+  fragment cloudinaryAssetFixed_noBase64 on CloudinaryAssetFixed {
     height
     src
     srcSet

--- a/packages/gatsby-transformer-cloudinary/upload.js
+++ b/packages/gatsby-transformer-cloudinary/upload.js
@@ -2,9 +2,10 @@ const cloudinary = require('cloudinary').v2;
 
 const DEFAULT_FLUID_MAX_WIDTH = 1000;
 const DEFAULT_FLUID_MIN_WIDTH = 200;
+const DEFAULT_PUBLIC_ID = (node) => node.name;
 
 exports.uploadImageNodeToCloudinary = async (node, options) => {
-  const {cloudName, apiKey, apiSecret, uploadFolder, fluidMaxWidth = DEFAULT_FLUID_MAX_WIDTH, fluidMinWidth = DEFAULT_FLUID_MIN_WIDTH, breakpointsMaxImages = 5, createDerived = true} =  options;
+  const {cloudName, apiKey, apiSecret, uploadFolder, publicId = DEFAULT_PUBLIC_ID, fluidMaxWidth = DEFAULT_FLUID_MAX_WIDTH, fluidMinWidth = DEFAULT_FLUID_MIN_WIDTH, breakpointsMaxImages = 5, createDerived = true} =  options;
   cloudinary.config({
     cloud_name: cloudName,
     api_key: apiKey,
@@ -13,8 +14,8 @@ exports.uploadImageNodeToCloudinary = async (node, options) => {
 
   try{
     const result = await cloudinary.uploader.upload(node.absolutePath, {
+      public_id: publicId(node),
       folder: uploadFolder,
-      public_id: node.name,
       resource_type: 'auto',
       responsive_breakpoints: [
         {


### PR DESCRIPTION
publicId option is a function that accepts a File node and returns a public_id. The default is using `node.name`.
Added no_base64 fragments