### PR TITLE
added overwrite option to transformer

### DIFF
--- a/packages/gatsby-transformer-cloudinary/README.md
+++ b/packages/gatsby-transformer-cloudinary/README.md
@@ -9,6 +9,7 @@ You’ll need a [Cloudinary account](https://cloudinary.com) to use this plugin.
 > **DISCLAIMER:** If you try running this demo's source code on your own computer, you might face issues as the demo uses assets and [transformations](https://cloudinary.com/documentation/chained_and_named_transformations#named_transformations) from the author’s Cloudinary account. Before running, please remove them or replace them with images and transformations from your own Cloudinary account.
 
 ## Features
+
 - Upload local project media assets to a secure remote CDN
 - Utilize media assets on Cloudinary in gatsby-image
 - Use gatsby-image `fluid` and `fixed` formats on Cloudinary assets
@@ -16,6 +17,7 @@ You’ll need a [Cloudinary account](https://cloudinary.com) to use this plugin.
 - Utilize all Cloudinary transformations including chained transformations in gatsby's data layer
 
 ## Example usage
+
 Here's the plugin in action to fetch a fixed asset using the `useStaticQuery` API of gatsby:
 
 ```jsx harmony

--- a/packages/gatsby-transformer-cloudinary/upload.js
+++ b/packages/gatsby-transformer-cloudinary/upload.js
@@ -4,7 +4,17 @@ const DEFAULT_FLUID_MAX_WIDTH = 1000;
 const DEFAULT_FLUID_MIN_WIDTH = 200;
 
 exports.uploadImageNodeToCloudinary = async (node, options) => {
-  const {cloudName, apiKey, apiSecret, uploadFolder, fluidMaxWidth = DEFAULT_FLUID_MAX_WIDTH, fluidMinWidth = DEFAULT_FLUID_MIN_WIDTH, breakpointsMaxImages = 5, createDerived = true} =  options;
+  const {
+    cloudName,
+    apiKey,
+    apiSecret,
+    uploadFolder,
+    fluidMaxWidth = DEFAULT_FLUID_MAX_WIDTH,
+    fluidMinWidth = DEFAULT_FLUID_MIN_WIDTH,
+    breakpointsMaxImages = 5,
+    createDerived = true,
+    overwrite = true,
+  } = options;
   cloudinary.config({
     cloud_name: cloudName,
     api_key: apiKey,
@@ -16,6 +26,7 @@ exports.uploadImageNodeToCloudinary = async (node, options) => {
       folder: uploadFolder,
       public_id: node.name,
       resource_type: 'auto',
+      overwrite,
       responsive_breakpoints: [
         {
           create_derived: createDerived,


### PR DESCRIPTION
I must admit i couldn't fully find whether this is the boolean key to pass through to cloudinary (the docs seemed to far rather the preset usage rather than passing them directly to the method) but I wanted to do this PR as a discussion either way.

I wondered as well whether in fact we were able to just to spread the rest of the options onto the cloudinary upload (in `upload.js` line 25) so that any option cloudinary supports the gatsby plugin could support as well