### PR TITLE
Fix cloudinary asset fluid limit presentation size

### DIFF
--- a/packages/gatsby-transformer-cloudinary/CHANGELOG.md
+++ b/packages/gatsby-transformer-cloudinary/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Version 1.0.1
+
+Other changes:
+
+- Added CloudinaryAssetFluidLimitPresentationSize fragment.
+- Added presentationHeight and presentationWidth to CloudinaryAssetFluid.
+
 # Version 1.0.0
 
 Breaking changes:

--- a/packages/gatsby-transformer-cloudinary/README.md
+++ b/packages/gatsby-transformer-cloudinary/README.md
@@ -187,6 +187,25 @@ export default () => {
 };
 ```
 
+### Avoiding stretched images using the fluid type
+
+As mentioned previously, images using the fluid type are stretched to match the container’s width and height. In the case where the image’s width or height is smaller than the available viewport, the image will stretch to match the container, potentially leading to unwanted problems and worsened image quality.
+
+The `CloudinaryAssetFluidLimitPresentationSize` fragment can be used to to `gatsby-image` not to stretch an image larger than its maximum dimensions regardless of the size of its container:
+
+```graphql
+query {
+  file(name: { eq: "avatar" }) {
+    childCloudinaryAsset {
+      fluid {
+        ...CloudinaryAssetFluid
+        ...CloudinaryAssetFluidLimitPresentationSize
+      }
+    }
+  }
+}
+```
+
 ## Manual Usage
 
 It’s also possible to manually create `gatsby-image`-friendly `fixed` and `fluid` objects by importing helper functions from the transformer.

--- a/packages/gatsby-transformer-cloudinary/gatsby-node.js
+++ b/packages/gatsby-transformer-cloudinary/gatsby-node.js
@@ -49,8 +49,6 @@ exports.createSchemaCustomization = ({ actions }) => {
       aspectRatio: Float
       base64: String!
       height: Float
-      presentationHeight: Float
-      presentationWidth: Float
       src: String
       srcSet: String
       width: Float
@@ -59,6 +57,8 @@ exports.createSchemaCustomization = ({ actions }) => {
     type CloudinaryAssetFluid {
       aspectRatio: Float!
       base64: String!
+      presentationHeight: Float
+      presentationWidth: Float
       sizes: String!
       src: String!
       srcSet: String!

--- a/packages/gatsby-transformer-cloudinary/package.json
+++ b/packages/gatsby-transformer-cloudinary/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-transformer-cloudinary",
-  "version": "1.0.2",
+  "version": "1.0.0",
   "description": "Transform local files into Cloudinary-managed assets for Gatsby sites.",
   "main": "index.js",
   "types": "index.d.ts",

--- a/packages/gatsby-transformer-cloudinary/package.json
+++ b/packages/gatsby-transformer-cloudinary/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-transformer-cloudinary",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Transform local files into Cloudinary-managed assets for Gatsby sites.",
   "main": "index.js",
   "types": "index.d.ts",

--- a/packages/gatsby-transformer-cloudinary/package.json
+++ b/packages/gatsby-transformer-cloudinary/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-transformer-cloudinary",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Transform local files into Cloudinary-managed assets for Gatsby sites.",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
The properties `presentationHeight` and `presentationWidth` were incorrectly added to `CloudinaryAssetFixed` instead of `CloudinaryAssetFluid` in #32.

This PR fixes that and adds documentation for how to use the `CloudinaryAssetFluidLimitPresentationSize` fragment.