### PR TITLE
Cache base64 responses

### DIFF
--- a/packages/gatsby-transformer-cloudinary/CHANGELOG.md
+++ b/packages/gatsby-transformer-cloudinary/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Version Next
+
+Additions:
+
+- Cached base64 images when running queries to prevent duplicate network requests.
+
 # Version 1.0.1
 
 Other changes:

--- a/packages/gatsby-transformer-cloudinary/CHANGELOG.md
+++ b/packages/gatsby-transformer-cloudinary/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Version Next
 
-Additions:
+Improvements:
 
 - Cached base64 images when running queries to prevent duplicate network requests.
 

--- a/packages/gatsby-transformer-cloudinary/get-image-objects.js
+++ b/packages/gatsby-transformer-cloudinary/get-image-objects.js
@@ -7,6 +7,8 @@ const { getPluginOptions } = require('./options');
 const DEFAULT_BASE64_WIDTH = 30;
 const DEFAULT_FIXED_WIDTH = 400;
 
+const base64Cache = {};
+
 // Create Cloudinary image URL with transformations.
 const getImageURL = ({
   public_id,
@@ -36,10 +38,13 @@ const getImageURL = ({
 
 // Fetch and return Base64 image
 const getBase64 = async url => {
-  const result = await axios.get(url, { responseType: 'arraybuffer' });
-  const data = Buffer.from(result.data).toString('base64');
+  if (!base64Cache[url]) {
+    const result = await axios.get(url, { responseType: 'arraybuffer' });
+    const data = Buffer.from(result.data).toString('base64');  
+    base64Cache[url] = `data:image/jpeg;base64,${data}`;
+  }
 
-  return `data:image/jpeg;base64,${data}`;
+  return base64Cache[url];
 };
 
 // retrieve aspect ratio if in transformation else create aspect ratio values

--- a/packages/gatsby-transformer-cloudinary/get-image-objects.js
+++ b/packages/gatsby-transformer-cloudinary/get-image-objects.js
@@ -40,7 +40,7 @@ const getImageURL = ({
 const getBase64 = async url => {
   if (!base64Cache[url]) {
     const result = await axios.get(url, { responseType: 'arraybuffer' });
-    const data = Buffer.from(result.data).toString('base64');  
+    const data = Buffer.from(result.data).toString('base64');
     base64Cache[url] = `data:image/jpeg;base64,${data}`;
   }
 

--- a/packages/gatsby-transformer-cloudinary/get-image-objects.test.js
+++ b/packages/gatsby-transformer-cloudinary/get-image-objects.test.js
@@ -1,9 +1,11 @@
 const { getFluidImageObject } = require('./get-image-objects');
 
-jest.mock('./options');
 jest.mock('axios');
+const { get } = require('axios');
+const base64ImageData = ['1', '2', '3'];
+get.mockReturnValue({ data: base64ImageData });
 
-const axios = require('axios');
+jest.mock('./options');
 const { getPluginOptions } = require('./options');
 
 function getDefaultArgs(args) {
@@ -23,41 +25,63 @@ function getDefaultOptions(options) {
   };
 }
 
-beforeEach(() => {
-  axios.get = jest.fn(() => ({ data: ['1', '2', '3'] }));
-});
+describe('getFluidImageObject', () => {
+  it('returns presentationWidth=fluidMaxWidth when fluidMaxWidth is smaller', async () => {
+    const options = getDefaultOptions();
+    getPluginOptions.mockReturnValue(options);
+    const args = getDefaultArgs();
 
-test('getFluidImageObject returns presentationWidth=fluidMaxWidth when fluidMaxWidth is smaller', async () => {
-  const options = getDefaultOptions();
-  getPluginOptions.mockReturnValue(options);
-  const args = getDefaultArgs();
+    const presentationWidth = options.fluidMaxWidth;
+    expect(await getFluidImageObject(args)).toEqual(
+      expect.objectContaining({ presentationWidth }),
+    );
+  });
 
-  const presentationWidth = options.fluidMaxWidth;
-  expect(await getFluidImageObject(args)).toEqual(
-    expect.objectContaining({ presentationWidth }),
-  );
-});
+  it('returns presentationWidth=originalWidth when originalWidth is smaller', async () => {
+    const options = getDefaultOptions({ fluidMaxWidth: 10000 });
+    getPluginOptions.mockReturnValue(options);
+    const args = getDefaultArgs();
 
-test('getFluidImageObject returns presentationWidth=originalWidth when originalWidth is smaller', async () => {
-  const options = getDefaultOptions({ fluidMaxWidth: 10000 });
-  getPluginOptions.mockReturnValue(options);
-  const args = getDefaultArgs();
+    const presentationWidth = args.originalWidth;
+    expect(await getFluidImageObject(args)).toEqual(
+      expect.objectContaining({ presentationWidth }),
+    );
+  });
 
-  const presentationWidth = args.originalWidth;
-  expect(await getFluidImageObject(args)).toEqual(
-    expect.objectContaining({ presentationWidth }),
-  );
-});
+  it('calculates presentation height', async () => {
+    const options = getDefaultOptions();
+    getPluginOptions.mockReturnValue(options);
+    const args = getDefaultArgs();
 
-test('getFluidImageObject calculates presentation height', async () => {
-  const options = getDefaultOptions();
-  getPluginOptions.mockReturnValue(options);
-  const args = getDefaultArgs();
+    const presentationHeight = Math.round(
+      (options.fluidMaxWidth * args.originalHeight) / args.originalWidth,
+    );
+    expect(await getFluidImageObject(args)).toEqual(
+      expect.objectContaining({ presentationHeight }),
+    );
+  });
 
-  const presentationHeight = Math.round(
-    (options.fluidMaxWidth * args.originalHeight) / args.originalWidth,
-  );
-  expect(await getFluidImageObject(args)).toEqual(
-    expect.objectContaining({ presentationHeight }),
-  );
+  it('returns a base64 image', async () => {
+    const options = getDefaultOptions();
+    getPluginOptions.mockReturnValue(options);
+    const args = getDefaultArgs();
+
+    const base64 = Buffer.from(base64ImageData).toString('base64');
+    const expectedBase64Image = `data:image/jpeg;base64,${base64}`;
+
+    expect(await getFluidImageObject(args)).toEqual(
+      expect.objectContaining({ base64: expectedBase64Image }),
+    );
+  });
+
+  it('does not fetch base64 images multiple times', async () => {
+    const options = getDefaultOptions();
+    getPluginOptions.mockReturnValue(options);
+    const args = getDefaultArgs();
+
+    for (let i = 1; i <= 3; i++) {
+      await getFluidImageObject(args);
+    }
+    expect(get).toHaveBeenCalledTimes(1);
+  });
 });


### PR DESCRIPTION
`gatsby-transformer-cloudinary` performs a network request to Cloudinary to get the base64 version of each image when Gatsby queries for an image. In the event that images are duplicated, we can reduce the number of network requests by caching the responses returned from Cloudinary.

In an application with many duplicated images, this dropped the `run page queries` portion of `gatsby develop` from around 700 seconds to under 10 seconds.