### PR TITLE
Height argument for fixed queries

### DIFF
--- a/packages/gatsby-transformer-cloudinary/CHANGELOG.md
+++ b/packages/gatsby-transformer-cloudinary/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Improvements:
 
+- Added an optional `height` argument to `fixed` queries.
 - Cached base64 images when running queries to prevent duplicate network requests.
 
 # Version 1.0.1

--- a/packages/gatsby-transformer-cloudinary/README.md
+++ b/packages/gatsby-transformer-cloudinary/README.md
@@ -285,9 +285,10 @@ Both `fixed` and `fluid` accept arguments. All arguments are optional.
 
 ### Arguments for `fixed`
 
-| argument | type  | default | description                                 |
-| -------- | ----- | ------- | ------------------------------------------- |
-| `width`  | `Int` | `400`   | The width that the image should display at. |
+| argument | type  | default | description                                                                                    |
+| -------- | ----- | ------- | ---------------------------------------------------------------------------------------------- |
+| `height` | `Int` | `n/a`   | The height that the image should display at. If `width` is provided, then `height` is ignored. |
+| `width`  | `Int` | `400`   | The width that the image should display at.                                                    |
 
 ### Arguments for `fluid`
 

--- a/packages/gatsby-transformer-cloudinary/gatsby-node.js
+++ b/packages/gatsby-transformer-cloudinary/gatsby-node.js
@@ -77,6 +77,7 @@ exports.createResolvers = ({ createResolvers }) => {
           {
             base64Width,
             base64Transformations,
+            height,
             width,
             transformations,
             chained,
@@ -88,6 +89,7 @@ exports.createResolvers = ({ createResolvers }) => {
             cloudName,
             originalHeight,
             originalWidth,
+            height,
             width,
             base64Width,
             base64Transformations,

--- a/packages/gatsby-transformer-cloudinary/gatsby-node.js
+++ b/packages/gatsby-transformer-cloudinary/gatsby-node.js
@@ -32,6 +32,7 @@ exports.createSchemaCustomization = ({ actions }) => {
         base64Width: Int
         base64Transformations: [String!]
         chained: [String!]
+        height: Int
         transformations: [String!]
         width: Int
       ): CloudinaryAssetFixed!

--- a/packages/gatsby-transformer-cloudinary/get-image-objects.js
+++ b/packages/gatsby-transformer-cloudinary/get-image-objects.js
@@ -125,11 +125,11 @@ exports.getFixedImageObject = async ({
 
   let displayWidth;
   if (!!width) {
-    displayWidth = width;
+    displayWidth = Math.min(width, originalWidth);
   } else if (!!height) {
-    displayWidth = height * aspectRatio;
+    displayWidth = Math.min(height * aspectRatio, originalWidth);
   } else if (!height && !width) {
-    displayWidth = DEFAULT_FIXED_WIDTH;
+    displayWidth = Math.min(DEFAULT_FIXED_WIDTH, originalWidth);
   }
 
   const sizes = [1, 1.5, 2, 3].map(size => ({

--- a/packages/gatsby-transformer-cloudinary/get-image-objects.js
+++ b/packages/gatsby-transformer-cloudinary/get-image-objects.js
@@ -101,7 +101,8 @@ exports.getFixedImageObject = async ({
   originalHeight,
   originalWidth,
   version = false,
-  width = DEFAULT_FIXED_WIDTH,
+  height,
+  width,
   base64Width = DEFAULT_BASE64_WIDTH,
   base64Transformations = [],
   transformations = [],
@@ -122,9 +123,18 @@ exports.getFixedImageObject = async ({
     originalWidth / originalHeight,
   );
 
+  let displayWidth;
+  if (!!width) {
+    displayWidth = width;
+  } else if (!!height) {
+    displayWidth = height * aspectRatio;
+  } else if (!height && !width) {
+    displayWidth = DEFAULT_FIXED_WIDTH;
+  }
+
   const sizes = [1, 1.5, 2, 3].map(size => ({
     resolution: size,
-    width: width * size,
+    width: Math.round(displayWidth * size),
   }));
 
   const srcSet = sizes
@@ -146,10 +156,10 @@ exports.getFixedImageObject = async ({
 
   return {
     base64,
-    height: width / aspectRatio,
+    height: Math.round(displayWidth / aspectRatio),
     src,
     srcSet,
-    width,
+    width: Math.round(displayWidth),
   };
 };
 

--- a/packages/gatsby-transformer-cloudinary/get-image-objects.test.js
+++ b/packages/gatsby-transformer-cloudinary/get-image-objects.test.js
@@ -106,6 +106,36 @@ describe('getFixedImageObject', () => {
     };
   }
 
+  it('uses a width of 400 px if no width is provided', async () => {
+    const options = getDefaultOptions();
+    getPluginOptions.mockReturnValue(options);
+    const args = getDefaultArgs();
+
+    expect(await getFixedImageObject(args)).toEqual(
+      expect.objectContaining({ width: 400 }),
+    );
+  });
+
+  it("uses the image's originalWidth if it is smaller than the requested width", async () => {
+    const options = getDefaultOptions();
+    getPluginOptions.mockReturnValue(options);
+    const args = getDefaultArgs({ width: 20000 });
+
+    expect(await getFixedImageObject(args)).toEqual(
+      expect.objectContaining({ width: 1920 }),
+    );
+  });
+
+  it("uses the image's originalWidth if it is smaller than the default width of 400 px", async () => {
+    const options = getDefaultOptions();
+    getPluginOptions.mockReturnValue(options);
+    const args = getDefaultArgs({ originalWidth: 100 });
+
+    expect(await getFixedImageObject(args)).toEqual(
+      expect.objectContaining({ width: 100 }),
+    );
+  });
+
   it('calculates the height based on the provided width', async () => {
     const options = getDefaultOptions();
     getPluginOptions.mockReturnValue(options);

--- a/packages/gatsby-transformer-cloudinary/get-image-objects.test.js
+++ b/packages/gatsby-transformer-cloudinary/get-image-objects.test.js
@@ -1,4 +1,7 @@
-const { getFluidImageObject } = require('./get-image-objects');
+const {
+  getFluidImageObject,
+  getFixedImageObject,
+} = require('./get-image-objects');
 
 jest.mock('axios');
 const { get } = require('axios');
@@ -8,24 +11,24 @@ get.mockReturnValue({ data: base64ImageData });
 jest.mock('./options');
 const { getPluginOptions } = require('./options');
 
-function getDefaultArgs(args) {
-  return {
-    public_id: 'public_id',
-    cloudName: 'cloudName',
-    originalWidth: 1920,
-    originalHeight: 1080,
-    ...args,
-  };
-}
-
-function getDefaultOptions(options) {
-  return {
-    fluidMaxWidth: 1000,
-    ...options,
-  };
-}
-
 describe('getFluidImageObject', () => {
+  function getDefaultArgs(args) {
+    return {
+      public_id: 'public_id',
+      cloudName: 'cloudName',
+      originalWidth: 1920,
+      originalHeight: 1080,
+      ...args,
+    };
+  }
+
+  function getDefaultOptions(options) {
+    return {
+      fluidMaxWidth: 1000,
+      ...options,
+    };
+  }
+
   it('returns presentationWidth=fluidMaxWidth when fluidMaxWidth is smaller', async () => {
     const options = getDefaultOptions();
     getPluginOptions.mockReturnValue(options);
@@ -58,6 +61,104 @@ describe('getFluidImageObject', () => {
     );
     expect(await getFluidImageObject(args)).toEqual(
       expect.objectContaining({ presentationHeight }),
+    );
+  });
+
+  it('returns a base64 image', async () => {
+    const options = getDefaultOptions();
+    getPluginOptions.mockReturnValue(options);
+    const args = getDefaultArgs();
+
+    const base64 = Buffer.from(base64ImageData).toString('base64');
+    const expectedBase64Image = `data:image/jpeg;base64,${base64}`;
+
+    expect(await getFluidImageObject(args)).toEqual(
+      expect.objectContaining({ base64: expectedBase64Image }),
+    );
+  });
+
+  it('does not fetch base64 images multiple times', async () => {
+    const options = getDefaultOptions();
+    getPluginOptions.mockReturnValue(options);
+    const args = getDefaultArgs();
+
+    for (let i = 1; i <= 3; i++) {
+      await getFluidImageObject(args);
+    }
+    expect(get).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('getFixedImageObject', () => {
+  function getDefaultArgs(args) {
+    return {
+      public_id: 'public_id',
+      cloudName: 'cloudName',
+      originalWidth: 1920,
+      originalHeight: 1080,
+      ...args,
+    };
+  }
+
+  function getDefaultOptions(options) {
+    return {
+      ...options,
+    };
+  }
+
+  it('calculates the height based on the provided width', async () => {
+    const options = getDefaultOptions();
+    getPluginOptions.mockReturnValue(options);
+    const args = getDefaultArgs({ width: 100 });
+
+    expect(await getFixedImageObject(args)).toEqual(
+      expect.objectContaining({ width: 100, height: 56 }),
+    );
+  });
+
+  it('calculates the width based on the provided height', async () => {
+    const options = getDefaultOptions();
+    getPluginOptions.mockReturnValue(options);
+    const args = getDefaultArgs({ height: 100 });
+
+    expect(await getFixedImageObject(args)).toEqual(
+      expect.objectContaining({ width: 178, height: 100 }),
+    );
+  });
+
+  it('creates a srcset with multiple images based on the provided width', async () => {
+    const options = getDefaultOptions();
+    getPluginOptions.mockReturnValue(options);
+    const args = getDefaultArgs({ width: 160 });
+
+    const expectedSrcSet = [
+      'https://res.cloudinary.com/cloudName/image/upload/w_160,f_auto,q_auto/public_id 1x',
+      'https://res.cloudinary.com/cloudName/image/upload/w_240,f_auto,q_auto/public_id 1.5x',
+      'https://res.cloudinary.com/cloudName/image/upload/w_320,f_auto,q_auto/public_id 2x',
+      'https://res.cloudinary.com/cloudName/image/upload/w_480,f_auto,q_auto/public_id 3x',
+    ];
+    expect(await getFixedImageObject(args)).toEqual(
+      expect.objectContaining({
+        srcSet: expectedSrcSet.join(','),
+      }),
+    );
+  });
+
+  it('creates a srcset with multiple images based on the provided height', async () => {
+    const options = getDefaultOptions();
+    getPluginOptions.mockReturnValue(options);
+    const args = getDefaultArgs({ height: 100 });
+
+    const expectedSrcSet = [
+      'https://res.cloudinary.com/cloudName/image/upload/w_178,f_auto,q_auto/public_id 1x',
+      'https://res.cloudinary.com/cloudName/image/upload/w_267,f_auto,q_auto/public_id 1.5x',
+      'https://res.cloudinary.com/cloudName/image/upload/w_356,f_auto,q_auto/public_id 2x',
+      'https://res.cloudinary.com/cloudName/image/upload/w_533,f_auto,q_auto/public_id 3x',
+    ];
+    expect(await getFixedImageObject(args)).toEqual(
+      expect.objectContaining({
+        srcSet: expectedSrcSet.join(','),
+      }),
     );
   });
 

--- a/packages/gatsby-transformer-cloudinary/package.json
+++ b/packages/gatsby-transformer-cloudinary/package.json
@@ -26,6 +26,7 @@
     "jest": "^26.1.0"
   },
   "scripts": {
-    "test": "jest"
+    "test": "jest",
+    "test:watch": "jest --watch"
   }
 }


### PR DESCRIPTION
This PR adds the ability to set the height of `fixed` images. For example, if you query with `height: 100`, then the smallest image in the srcSet will have a height of 100. The rest of the srcSet images will have heights that are multiples of the provided height.