### PR TITLE
Fix children cloudinary asset

### DIFF
--- a/packages/gatsby-transformer-cloudinary/upload.js
+++ b/packages/gatsby-transformer-cloudinary/upload.js
@@ -93,7 +93,8 @@ exports.uploadImageToCloudinary = async ({
 
 exports.uploadImageNodeToCloudinary = async ({ node, reporter }) => {
   const url = node.absolutePath;
-  const publicId = node.name;
+  const relativePathWithoutExtension = node.relativePath.replace(/\.[^.]*$/, "");
+  const publicId = relativePathWithoutExtension;
   const result = await exports.uploadImageToCloudinary({
     url,
     publicId,

--- a/packages/gatsby-transformer-cloudinary/upload.test.js
+++ b/packages/gatsby-transformer-cloudinary/upload.test.js
@@ -1,4 +1,7 @@
-const { uploadImageToCloudinary } = require('./upload');
+const {
+  uploadImageToCloudinary,
+  uploadImageNodeToCloudinary,
+} = require('./upload');
 
 jest.mock('./options');
 jest.mock('cloudinary');
@@ -118,5 +121,26 @@ describe('uploadImageToCloudinary', () => {
 
     const args = getDefaultArgs();
     expect(await uploadImageToCloudinary(args)).toEqual(cloudinaryUploadResult);
+  });
+});
+
+describe('uploadImageNodeToCloudinary', () => {
+  it("uses the image's relative path without the extension as the public ID", async () => {
+    const cloudinaryUpload = jest.fn();
+    cloudinary.uploader.upload = cloudinaryUpload;
+
+    const reporter = { info: jest.fn() };
+    const node = {
+      relativePath: 'folder-name/image.name.with.dots.jpg',
+    };
+
+    await uploadImageNodeToCloudinary({ node, reporter });
+
+    expect(cloudinaryUpload).toHaveBeenCalledWith(
+      undefined,
+      expect.objectContaining({
+        public_id: 'folder-name/image.name.with.dots',
+      }),
+    );
   });
 });


### PR DESCRIPTION
# Problem
If multiple images in the file system have the same file name, they are uploaded with the same public ID. This causes Gatsby to put them in GraphQL as childrenCloudinaryAsset instead of childCloudinaryAsset.

# Solution
When uploading images from the file system, use their path (minus their extension) as their public ID.