### PR TITLE
Use overwriteExisiting from options if not provided

### DIFF
--- a/packages/gatsby-transformer-cloudinary/CHANGELOG.md
+++ b/packages/gatsby-transformer-cloudinary/CHANGELOG.md
@@ -1,3 +1,32 @@
+# Version 2.0.0
+
+Changes:
+
+- This is a major version bump to call attention to the change in default behavior introduced in version 1.1.1. (`f_auto` and `q_auto` are no longer added to image URLs by default.)
+
+Fixes:
+
+- Images uploaded using the `createRemoteImageNode` function respect the `overwriteExisting` argument when provided and fall back to using the `overwriteExisting` plugin option.
+
+# Version 1.1.3
+
+Fixes:
+
+- Typo fix.
+
+
+# Version 1.1.2
+
+Fixes:
+
+- Local images uploaded to Cloudinary now respect the `overwriteExisting` plugin option.
+
+# Version 1.1.1
+
+Changes:
+
+- Added `enableDefaultTransformations` plugin option. When set to true, `f_auto` and `q_auto` are added to all source URLs automatically. Previously, this was on by default. This behavior is now opt-in.
+
 # Version 1.1.0
 
 Additions:

--- a/packages/gatsby-transformer-cloudinary/CHANGELOG.md
+++ b/packages/gatsby-transformer-cloudinary/CHANGELOG.md
@@ -14,7 +14,6 @@ Fixes:
 
 - Typo fix.
 
-
 # Version 1.1.2
 
 Fixes:

--- a/packages/gatsby-transformer-cloudinary/README.md
+++ b/packages/gatsby-transformer-cloudinary/README.md
@@ -328,6 +328,20 @@ You’re able to change the aspect ratio of images by supplying the [aspect rati
 
 > **NOTE:** The aspect ratio _must_ be supplied in the `transformations` array. It **will not** be picked up from the `chained` argument.
 
+## Running Tests
+
+Run the tests once:
+
+```
+yarn workspace gatsby-transformer-cloudinary test
+```
+
+Run the tests in watch mode:
+
+```
+yarn workspace gatsby-transformer-cloudinary test:watch
+```
+
 ## Other Resources
 
 - [Cloudinary image transformation reference](https://cloudinary.com/documentation/image_transformation_reference)

--- a/packages/gatsby-transformer-cloudinary/package.json
+++ b/packages/gatsby-transformer-cloudinary/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-transformer-cloudinary",
-  "version": "1.1.3",
+  "version": "2.0.0",
   "description": "Transform local files into Cloudinary-managed assets for Gatsby sites.",
   "main": "index.js",
   "types": "index.d.ts",

--- a/packages/gatsby-transformer-cloudinary/upload.js
+++ b/packages/gatsby-transformer-cloudinary/upload.js
@@ -9,6 +9,7 @@ const FIVE_MINUTES = 5 * 60 * 1000;
 exports.uploadImageToCloudinary = async ({
   url,
   publicId,
+  overwrite,
   reporter,
 }) => {
   const {
@@ -20,7 +21,6 @@ exports.uploadImageToCloudinary = async ({
     fluidMaxWidth,
     fluidMinWidth,
     uploadFolder,
-    overwriteExisting,
     useCloudinaryBreakpoints,
   } = getPluginOptions();
   cloudinary.config({
@@ -31,7 +31,7 @@ exports.uploadImageToCloudinary = async ({
 
   const uploadOptions = {
     folder: uploadFolder,
-    overwrite: overwriteExisting,
+    overwrite,
     public_id: publicId,
     resource_type: 'auto',
     timeout: FIVE_MINUTES,
@@ -93,11 +93,16 @@ exports.uploadImageToCloudinary = async ({
 
 exports.uploadImageNodeToCloudinary = async ({ node, reporter }) => {
   const url = node.absolutePath;
-  const relativePathWithoutExtension = node.relativePath.replace(/\.[^.]*$/, "");
+  const relativePathWithoutExtension = node.relativePath.replace(
+    /\.[^.]*$/,
+    '',
+  );
   const publicId = relativePathWithoutExtension;
+  const overwrite = getPluginOptions().overwriteExisting;
   const result = await exports.uploadImageToCloudinary({
     url,
     publicId,
+    overwrite,
     reporter,
   });
   return result;

--- a/packages/gatsby-transformer-cloudinary/upload.test.js
+++ b/packages/gatsby-transformer-cloudinary/upload.test.js
@@ -13,7 +13,7 @@ describe('uploadImageToCloudinary', () => {
   function getDefaultArgs(args) {
     return {
       url: 'url',
-      // overwrite: 'overwrite',
+      overwrite: 'overwrite',
       publicId: 'publicId',
       reporter: {
         info: jest.fn(),
@@ -30,7 +30,6 @@ describe('uploadImageToCloudinary', () => {
       apiKey: 'apiKey',
       apiSecret: 'apiSecret',
       uploadFolder: 'uploadFolder',
-      overwriteExisting: false,
       createDerived: false,
       breakpointsMaxImages: 234,
       fluidMaxWidth: 345,
@@ -39,7 +38,7 @@ describe('uploadImageToCloudinary', () => {
     };
   }
 
-  test('configures cloudinary with the appropriate plugin options', async () => {
+  it('configures cloudinary with the appropriate plugin options', async () => {
     const cloudinaryConfig = jest.fn();
     cloudinary.config = cloudinaryConfig;
 
@@ -57,7 +56,7 @@ describe('uploadImageToCloudinary', () => {
     expect(cloudinaryConfig).toHaveBeenCalledWith(expected);
   });
 
-  test('does not ask for responsive breakpoints when useCloudinaryBreakpoints is false', async () => {
+  it('does not ask for responsive breakpoints when useCloudinaryBreakpoints is false', async () => {
     const cloudinaryUpload = jest.fn();
     cloudinary.uploader.upload = cloudinaryUpload;
 
@@ -70,7 +69,7 @@ describe('uploadImageToCloudinary', () => {
     const expectedUrl = args.url;
     const expectedOptions = {
       folder: options.uploadFolder,
-      overwrite: options.overwriteExisting,
+      overwrite: args.overwrite,
       public_id: args.publicId,
       resource_type: 'auto',
       timeout: 5 * 60 * 1000,
@@ -78,14 +77,14 @@ describe('uploadImageToCloudinary', () => {
     expect(cloudinaryUpload).toHaveBeenCalledWith(expectedUrl, expectedOptions);
   });
 
-  test('overwrite only when overwriteExisting is set to true', async () => {
+  it('overwrites when passed overwrite:true', async () => {
     const cloudinaryUpload = jest.fn();
     cloudinary.uploader.upload = cloudinaryUpload;
 
-    const options = getDefaultOptions({ overwriteExisting: true });
+    const options = getDefaultOptions();
     getPluginOptions.mockReturnValue(options);
 
-    const args = getDefaultArgs();
+    const args = getDefaultArgs({ overwrite: true });
     await uploadImageToCloudinary(args);
 
     const expectedUrl = args.url;
@@ -99,7 +98,7 @@ describe('uploadImageToCloudinary', () => {
     expect(cloudinaryUpload).toHaveBeenCalledWith(expectedUrl, expectedOptions);
   });
 
-  test('asks for responsive breakpoints when useCloudinaryBreakpoints is true', async () => {
+  it('asks for responsive breakpoints when useCloudinaryBreakpoints is true', async () => {
     const cloudinaryUpload = jest.fn();
     cloudinary.uploader.upload = cloudinaryUpload;
 
@@ -115,7 +114,7 @@ describe('uploadImageToCloudinary', () => {
     const expectedUrl = args.url;
     const expectedOptions = {
       folder: options.uploadFolder,
-      overwrite: options.overwriteExisting,
+      overwrite: args.overwrite,
       public_id: args.publicId,
       resource_type: 'auto',
       timeout: 5 * 60 * 1000,
@@ -132,7 +131,7 @@ describe('uploadImageToCloudinary', () => {
     expect(cloudinaryUpload).toHaveBeenCalledWith(expectedUrl, expectedOptions);
   });
 
-  test('returns the result returned from the Cloudinary uploader', async () => {
+  it('returns the result returned from the Cloudinary uploader', async () => {
     const cloudinaryUpload = jest.fn();
     const cloudinaryUploadResult = 'cloudinaryUploadResult';
     cloudinaryUpload.mockReturnValue(cloudinaryUploadResult);
@@ -162,6 +161,27 @@ describe('uploadImageNodeToCloudinary', () => {
       undefined,
       expect.objectContaining({
         public_id: 'folder-name/image.name.with.dots',
+      }),
+    );
+  });
+
+  it('passes the overwrite setting from the plugin options', async () => {
+    const cloudinaryUpload = jest.fn();
+    cloudinary.uploader.upload = cloudinaryUpload;
+
+    const reporter = { info: jest.fn() };
+    const node = {
+      relativePath: 'relativePath.jpg',
+    };
+    const overwriteExisting = 'overwriteExistingDouble';
+    getPluginOptions.mockReturnValue({ overwriteExisting });
+
+    await uploadImageNodeToCloudinary({ node, reporter });
+
+    expect(cloudinaryUpload).toHaveBeenCalledWith(
+      undefined,
+      expect.objectContaining({
+        overwrite: overwriteExisting,
       }),
     );
   });


### PR DESCRIPTION
This PR updates `createRemoteImageNode` to use the plugin option `overwriteExisting` when it is not given an `overwrite` argument.