### PR TITLE
Log cloudinary api calls

### DIFF
--- a/packages/gatsby-transformer-cloudinary/CHANGELOG.md
+++ b/packages/gatsby-transformer-cloudinary/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Version Next
+
+Additions:
+
+- Added logging for each time we have to fetch a base64 image from Cloudinary to explain long query steps in the Gatsby build process.
+
 # Version 2.1.0
 
 Additions:

--- a/packages/gatsby-transformer-cloudinary/gatsby-node.js
+++ b/packages/gatsby-transformer-cloudinary/gatsby-node.js
@@ -72,7 +72,7 @@ exports.createSchemaCustomization = ({ actions }) => {
   `);
 };
 
-exports.createResolvers = ({ createResolvers }) => {
+exports.createResolvers = ({ createResolvers, reporter }) => {
   const resolvers = {
     CloudinaryAsset: {
       fixed: {
@@ -97,19 +97,20 @@ exports.createResolvers = ({ createResolvers }) => {
           },
         ) =>
           getFixedImageObject({
-            public_id,
-            version,
+            base64Transformations,
+            base64Width,
+            chained,
             cloudName,
+            defaultBase64,
+            height,
+            ignoreDefaultBase64,
             originalHeight,
             originalWidth,
-            height,
-            width,
-            base64Width,
-            base64Transformations,
-            defaultBase64,
-            ignoreDefaultBase64,
+            public_id,
+            reporter,
             transformations,
-            chained,
+            version,
+            width,
           }),
       },
       fluid: {
@@ -132,17 +133,18 @@ exports.createResolvers = ({ createResolvers }) => {
           },
         ) =>
           getFluidImageObject({
-            public_id,
-            version,
+            base64Transformations,
+            base64Width,
+            breakpoints,
+            chained,
             cloudName,
             maxWidth,
-            breakpoints,
             originalHeight,
             originalWidth,
-            base64Width,
-            base64Transformations,
+            public_id,
+            reporter,
             transformations,
-            chained,
+            version,
           }),
       },
     },

--- a/packages/gatsby-transformer-cloudinary/get-image-objects.js
+++ b/packages/gatsby-transformer-cloudinary/get-image-objects.js
@@ -11,30 +11,32 @@ const {
 const DEFAULT_BASE64_WIDTH = 30;
 
 exports.getFixedImageObject = async ({
-  public_id,
+  base64Transformations = [],
+  base64Width = DEFAULT_BASE64_WIDTH,
+  chained = [],
   cloudName,
+  defaultBase64,
+  height,
+  ignoreDefaultBase64 = false,
   originalHeight,
   originalWidth,
-  version = false,
-  height,
-  width,
-  base64Width = DEFAULT_BASE64_WIDTH,
-  base64Transformations = [],
-  defaultBase64,
-  ignoreDefaultBase64 = false,
+  public_id,
+  reporter = {},
   transformations = [],
-  chained = [],
+  version = false,
+  width,
 }) => {
   const base64 = await getBase64({
+    base64Transformations,
+    base64Width,
+    chained,
+    cloudName,
     defaultBase64,
     ignoreDefaultBase64,
     public_id,
-    version,
-    cloudName,
-    base64Transformations,
+    reporter,
     transformations,
-    base64Width,
-    chained,
+    version,
   });
 
   const src = getImageURL({
@@ -104,19 +106,20 @@ exports.getFixedImageObject = async ({
 };
 
 exports.getFluidImageObject = async ({
-  public_id,
-  cloudName,
-  originalWidth,
-  originalHeight,
-  breakpoints = [200, 400, 600],
-  version = false,
-  maxWidth,
-  base64Width = DEFAULT_BASE64_WIDTH,
   base64Transformations = [],
+  base64Width = DEFAULT_BASE64_WIDTH,
+  breakpoints = [200, 400, 600],
+  chained = [],
+  cloudName,
   defaultBase64,
   ignoreDefaultBase64 = false,
+  maxWidth,
+  originalHeight,
+  originalWidth,
+  public_id,
+  reporter = {},
   transformations = [],
-  chained = [],
+  version = false,
 }) => {
   const aspectRatio = getAspectRatio(
     transformations,
@@ -126,15 +129,16 @@ exports.getFluidImageObject = async ({
   const max = Math.min(maxWidth ? maxWidth : fluidMaxWidth, originalWidth);
   const sizes = `(max-width: ${max}px) 100vw, ${max}px`;
   const base64 = await getBase64({
+    base64Transformations,
+    base64Width,
+    chained,
+    cloudName,
     defaultBase64,
     ignoreDefaultBase64,
     public_id,
-    version,
-    cloudName,
-    base64Transformations,
-    base64Width,
+    reporter,
     transformations,
-    chained,
+    version,
   });
   const src = getImageURL({
     public_id,

--- a/packages/gatsby-transformer-cloudinary/get-image-objects/get-shared-image-data.js
+++ b/packages/gatsby-transformer-cloudinary/get-image-objects/get-shared-image-data.js
@@ -81,8 +81,16 @@ exports.getBase64 = async ({
   return base64;
 };
 
-async function fetchBase64(url) {
+let base64ImageCount = 0;
+
+async function fetchBase64(url, reporter) {
   if (!base64Cache[url]) {
+    base64ImageCount += 1;
+    if (typeof reporter.info === 'function')
+      reporter.info(
+        `[gatsby-transformer-cloudinary] Fetching base64 image ` +
+          `#${base64ImageCount} from Cloudinary: ${url}`,
+      );
     const result = await axios.get(url, { responseType: 'arraybuffer' });
     const data = Buffer.from(result.data).toString('base64');
     base64Cache[url] = `data:image/jpeg;base64,${data}`;

--- a/packages/gatsby-transformer-cloudinary/get-image-objects/get-shared-image-data.js
+++ b/packages/gatsby-transformer-cloudinary/get-image-objects/get-shared-image-data.js
@@ -52,15 +52,16 @@ exports.getAspectRatio = (transformations, originalAspectRatio) => {
 };
 
 exports.getBase64 = async ({
+  base64Transformations,
+  base64Width,
+  chained,
+  cloudName,
   defaultBase64,
   ignoreDefaultBase64,
   public_id,
-  version,
-  cloudName,
-  base64Transformations,
+  reporter,
   transformations,
-  base64Width,
-  chained,
+  version,
 }) => {
   if (defaultBase64) {
     if (!ignoreDefaultBase64 || getPluginOptions().alwaysUseDefaultBase64) {
@@ -76,7 +77,7 @@ exports.getBase64 = async ({
     cloudName,
     chained,
   });
-  const base64 = await fetchBase64(base64URL);
+  const base64 = await fetchBase64(base64URL, reporter);
 
   return base64;
 };

--- a/packages/gatsby-transformer-cloudinary/get-image-objects/get-shared-image-data.js
+++ b/packages/gatsby-transformer-cloudinary/get-image-objects/get-shared-image-data.js
@@ -82,20 +82,25 @@ exports.getBase64 = async ({
   return base64;
 };
 
-let base64ImageCount = 0;
-
 async function fetchBase64(url, reporter) {
   if (!base64Cache[url]) {
-    base64ImageCount += 1;
-    if (typeof reporter.info === 'function')
-      reporter.info(
-        `[gatsby-transformer-cloudinary] Fetching base64 image ` +
-          `#${base64ImageCount} from Cloudinary: ${url}`,
-      );
+    logBase64Retrieval(url, reporter);
     const result = await axios.get(url, { responseType: 'arraybuffer' });
     const data = Buffer.from(result.data).toString('base64');
     base64Cache[url] = `data:image/jpeg;base64,${data}`;
   }
 
   return base64Cache[url];
+}
+
+let fetchedBase64ImageCount = 0;
+
+function logBase64Retrieval(url, reporter) {
+  fetchedBase64ImageCount += 1;
+  if (typeof reporter.info === 'function') {
+    reporter.info(
+      `[gatsby-transformer-cloudinary] Fetching base64 image ` +
+        `#${fetchedBase64ImageCount} from Cloudinary: ${url}`,
+    );
+  }
 }

--- a/packages/gatsby-transformer-cloudinary/get-image-objects/get-shared-image-data.js
+++ b/packages/gatsby-transformer-cloudinary/get-image-objects/get-shared-image-data.js
@@ -102,5 +102,34 @@ function logBase64Retrieval(url, reporter) {
       `[gatsby-transformer-cloudinary] Fetching base64 image ` +
         `#${fetchedBase64ImageCount} from Cloudinary: ${url}`,
     );
+    if (fetchedBase64ImageCount == 100) {
+      reporter.info(
+        '[gatsby-transformer-cloudinary] ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~',
+      );
+      reporter.info(
+        'It looks like your project has a lot of images. To improve your build times, ',
+      );
+      reporter.info(
+        'you should consider (1) using images that are already on Cloudinary, (2) ',
+      );
+      reporter.info(
+        'precomputing the base64 images and providing them to this plugin as the ',
+      );
+      reporter.info(
+        '`defaultBase64` property, and (3) setting the plugin option ',
+      );
+      reporter.info(
+        '`alwaysUseDefaultBase64` to true. Doing so will reduce the number of base64 ',
+      );
+      reporter.info(
+        'images that need to be fetched from Cloudinary and speed up your Gatsby "query" ',
+      );
+      reporter.info(
+        'build steps. (See the section "Use images already on Cloudinary" in the README.)',
+      );
+      reporter.info(
+        '[gatsby-transformer-cloudinary] ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~',
+      );
+    }
   }
 }


### PR DESCRIPTION
When using `gatsby-transformer-cloudinary`, the `run page queries` step often takes a long time without any output. This is problematic because the user doesn't know what is taking so long.

This PR logs each time an API call to Cloudinary is made. It also points users to the README and how they can speed up their build times if they're too slow.

![image](https://user-images.githubusercontent.com/1914753/101783546-678b8880-3ac8-11eb-9d7e-1c0e10a25e90.png)

![image](https://user-images.githubusercontent.com/1914753/101786643-2a28fa00-3acc-11eb-8626-198e6fbd744d.png)