### PR TITLE
Fix fluid defaultBase64 images

### DIFF
--- a/packages/gatsby-transformer-cloudinary/CHANGELOG.md
+++ b/packages/gatsby-transformer-cloudinary/CHANGELOG.md
@@ -4,6 +4,10 @@ Additions:
 
 - Added logging for each time we have to fetch a base64 image from Cloudinary to explain long query steps in the Gatsby build process.
 
+Fixes:
+
+- Fluid images use defaultBase64 images when they are provided.
+
 # Version 2.1.0
 
 Additions:

--- a/packages/gatsby-transformer-cloudinary/gatsby-node.js
+++ b/packages/gatsby-transformer-cloudinary/gatsby-node.js
@@ -117,19 +117,21 @@ exports.createResolvers = ({ createResolvers, reporter }) => {
         type: 'CloudinaryAssetFluid!',
         resolve: (
           {
-            public_id,
-            version,
+            breakpoints,
             cloudName,
+            defaultBase64,
             originalHeight,
             originalWidth,
-            breakpoints,
+            public_id,
+            version,
           },
           {
-            base64Width,
             base64Transformations,
+            base64Width,
+            chained,
+            ignoreDefaultBase64,
             maxWidth,
             transformations,
-            chained,
           },
         ) =>
           getFluidImageObject({
@@ -138,6 +140,8 @@ exports.createResolvers = ({ createResolvers, reporter }) => {
             breakpoints,
             chained,
             cloudName,
+            defaultBase64,
+            ignoreDefaultBase64,
             maxWidth,
             originalHeight,
             originalWidth,


### PR DESCRIPTION
This PR fixes an issue that prevented fluid images from using precomputed base64 images.

Before this fix, fluid queries always downloaded base64 images from Cloudinary.

The problem was that base64 images were not being passed from the fluid image resolver to `getFluidImageObject`.