### PR TITLE
Add default traced svg properties

### DIFF
--- a/packages/gatsby-transformer-cloudinary/CHANGELOG.md
+++ b/packages/gatsby-transformer-cloudinary/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Additions:
 
+- defaultTracedSVG values are now passed along as tracedSVG values.
+
+# Version 2.1.1
+
+Additions:
+
 - Added logging for each time we have to fetch a base64 image from Cloudinary to explain long query steps in the Gatsby build process.
 
 Fixes:

--- a/packages/gatsby-transformer-cloudinary/README.md
+++ b/packages/gatsby-transformer-cloudinary/README.md
@@ -161,6 +161,7 @@ To create GraphQL nodes for images that are already uploaded to Cloudinary, you 
     originalHeight: 360,
     originalWidth: 820,
     defaultBase64: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mMMXG/8HwAEwAI0Bj1bnwAAAABJRU5ErkJggg==",
+    defaultTracedSVG: "data:image/svg+xml,%3Csvg%20height%3D%229999%22%20viewBox%3D%220%200%209999%209999%22%20width%3D%229999%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20d%3D%22m0%200h9999v9999h-9999z%22%20fill%3D%22%23f9fafb%22%2F%3E%3C%2Fsvg%3E",
   }
 }
 ```
@@ -170,6 +171,8 @@ The `coverPhoto` property in the node above will be deleted and replaced by `gat
 The property `defaultBase64` in the node above can be used by your CMS/backend API to provide precomputed or cached base64 URIs for your images. The provided string must comply with [RFC 2397](https://tools.ietf.org/html/rfc2397). This base64 image will be used unless `ignoreDefaultBase64: true` is set in your GraphQL query. In cases where you prefer to have an accurate base64 image with the same transformations applied as you full-size image, you should use `ignoreDefaultBase64: true` in your GraphQL query. When a defaultBase64 property is not supplied or `ignoreDefaultBase64` is true, an API call to Cloudinary will be made when resolving your GraphQL queries to fetch the base64 image.
 
 When providing `defaultBase64` properties, it's recommended that you set the plugin option `alwaysUseDefaultBase64` to true in development. This may result in your base64 images looking different in development and production, but it will also result in much faster development build times as fewer API calls to Cloudinary will be made. The `alwaysUseDefaultBase64` plugin option overrides the `ignoreDefaultBase64` GraphQL query parameter and forces `gatsby-transformer-cloudinary` to always use `defaultBase64` images when they are provided.
+
+The property `defaultTracedSVG` in the node above can be used by your CMS/backend to provide precomputed or cached SVG placeholders for your images. The provided string must comply with [RFC 2397](https://tools.ietf.org/html/rfc2397). It should also be encoded with something like JavaScript's `encodeURIComponent()`.
 
 ### Plugin options
 
@@ -217,6 +220,17 @@ export default () => {
   return <Image fluid={data.file.childCloudinaryAsset.fluid} alt="avatar" />;
 };
 ```
+
+### Fragments
+
+The fragments below can be used when querying your Cloudinary assets:
+
+- `CloudinaryAssetFluid`
+- `CloudinaryAssetFluid_noBase64`
+- `CloudinaryAssetFluid_tracedSVG`
+- `CloudinaryAssetFixed`
+- `CloudinaryAssetFixed_noBase64`
+- `CloudinaryAssetFixed_tracedSVG`
 
 ### Avoiding stretched images using the fluid type
 

--- a/packages/gatsby-transformer-cloudinary/create-image-node.js
+++ b/packages/gatsby-transformer-cloudinary/create-image-node.js
@@ -36,6 +36,7 @@ exports.createImageNode = ({
   createNodeId,
   cloudName,
   defaultBase64,
+  defaultTracedSVG,
 }) => {
   let breakpoints = getDefaultBreakpoints(width);
   if (
@@ -68,6 +69,7 @@ exports.createImageNode = ({
     originalWidth: width,
     breakpoints,
     defaultBase64,
+    defaultTracedSVG,
 
     // Add the required internal Gatsby node fields.
     id: createNodeId(`CloudinaryAsset-${fingerprint}`),

--- a/packages/gatsby-transformer-cloudinary/create-image-node.test.js
+++ b/packages/gatsby-transformer-cloudinary/create-image-node.test.js
@@ -161,6 +161,19 @@ describe('createImageNode', () => {
     expect(actual).toEqual(expect.objectContaining(expected));
   });
 
+  it('sets the defaultTracedSVG image', async () => {
+    const options = getDefaultOptions();
+    getPluginOptions.mockReturnValue(options);
+
+    const args = getDefaultArgs({
+      defaultTracedSVG: 'defaultTracedSVG',
+    });
+    const actual = createImageNode(args);
+
+    const expected = { defaultTracedSVG: 'defaultTracedSVG' };
+    expect(actual).toEqual(expect.objectContaining(expected));
+  });
+
   it('creates a node ID', async () => {
     const options = getDefaultOptions();
     getPluginOptions.mockReturnValue(options);

--- a/packages/gatsby-transformer-cloudinary/fragments.js
+++ b/packages/gatsby-transformer-cloudinary/fragments.js
@@ -10,6 +10,25 @@ export const cloudinaryAssetFluid = graphql`
   }
 `;
 
+export const cloudinaryAssetFluidNoBase64 = graphql`
+  fragment CloudinaryAssetFluid_noBase64 on CloudinaryAssetFluid {
+    aspectRatio
+    sizes
+    src
+    srcSet
+  }
+`;
+
+export const cloudinaryAssetFluidTracedSVG = graphql`
+  fragment CloudinaryAssetFluid_tracedSVG on CloudinaryAssetFluid {
+    aspectRatio
+    sizes
+    src
+    srcSet
+    tracedSVG
+  }
+`;
+
 export const cloudinaryAssetFluidLimitPresentationSize = graphql`
   fragment CloudinaryAssetFluidLimitPresentationSize on CloudinaryAssetFluid {
     maxHeight: presentationHeight
@@ -23,6 +42,25 @@ export const cloudinaryAssetFixed = graphql`
     height
     src
     srcSet
+    width
+  }
+`;
+
+export const cloudinaryAssetFixedNoBase64 = graphql`
+  fragment CloudinaryAssetFixed_noBase64 on CloudinaryAssetFixed {
+    height
+    src
+    srcSet
+    width
+  }
+`;
+
+export const cloudinaryAssetFixedTracedSVG = graphql`
+  fragment CloudinaryAssetFixed_tracedSVG on CloudinaryAssetFixed {
+    height
+    src
+    srcSet
+    tracedSVG
     width
   }
 `;

--- a/packages/gatsby-transformer-cloudinary/gatsby-node.js
+++ b/packages/gatsby-transformer-cloudinary/gatsby-node.js
@@ -57,6 +57,7 @@ exports.createSchemaCustomization = ({ actions }) => {
       height: Float
       src: String
       srcSet: String
+      tracedSVG: String
       width: Float
     }
 
@@ -68,6 +69,7 @@ exports.createSchemaCustomization = ({ actions }) => {
       sizes: String!
       src: String!
       srcSet: String!
+      tracedSVG: String
     }
   `);
 };
@@ -85,6 +87,7 @@ exports.createResolvers = ({ createResolvers, reporter }) => {
             originalHeight,
             originalWidth,
             defaultBase64,
+            defaultTracedSVG,
           },
           {
             base64Width,
@@ -102,6 +105,7 @@ exports.createResolvers = ({ createResolvers, reporter }) => {
             chained,
             cloudName,
             defaultBase64,
+            defaultTracedSVG,
             height,
             ignoreDefaultBase64,
             originalHeight,
@@ -120,6 +124,7 @@ exports.createResolvers = ({ createResolvers, reporter }) => {
             breakpoints,
             cloudName,
             defaultBase64,
+            defaultTracedSVG,
             originalHeight,
             originalWidth,
             public_id,
@@ -141,6 +146,7 @@ exports.createResolvers = ({ createResolvers, reporter }) => {
             chained,
             cloudName,
             defaultBase64,
+            defaultTracedSVG,
             ignoreDefaultBase64,
             maxWidth,
             originalHeight,

--- a/packages/gatsby-transformer-cloudinary/gatsby-node/create-asset-nodes-from-data.js
+++ b/packages/gatsby-transformer-cloudinary/gatsby-node/create-asset-nodes-from-data.js
@@ -84,6 +84,7 @@ function createCloudinaryAssetNode({
   assetData: {
     cloudName,
     defaultBase64,
+    defaultTracedSVG,
     originalHeight,
     originalWidth,
     publicId,
@@ -110,6 +111,7 @@ function createCloudinaryAssetNode({
     createNodeId,
     parentNode,
     defaultBase64,
+    defaultTracedSVG,
   });
 
   // Add the new node to Gatsby’s data layer.

--- a/packages/gatsby-transformer-cloudinary/gatsby-node/create-asset-nodes-from-data.test.js
+++ b/packages/gatsby-transformer-cloudinary/gatsby-node/create-asset-nodes-from-data.test.js
@@ -22,6 +22,7 @@ describe('createAssetNodesFromData', () => {
           originalHeight: 1080,
           originalWidth: 1920,
           defaultBase64: 'defaultBase64',
+          defaultTracedSVG: 'defaultTracedSVG',
         },
       },
       actions: { createNode: jest.fn() },
@@ -99,6 +100,7 @@ describe('createAssetNodesFromData', () => {
         createNodeId: args.createNodeId,
         parentNode: args.node,
         defaultBase64: assetData.defaultBase64,
+        defaultTracedSVG: assetData.defaultTracedSVG,
       }),
     );
   });

--- a/packages/gatsby-transformer-cloudinary/get-image-objects.js
+++ b/packages/gatsby-transformer-cloudinary/get-image-objects.js
@@ -16,6 +16,7 @@ exports.getFixedImageObject = async ({
   chained = [],
   cloudName,
   defaultBase64,
+  defaultTracedSVG,
   height,
   ignoreDefaultBase64 = false,
   originalHeight,
@@ -101,6 +102,7 @@ exports.getFixedImageObject = async ({
     height: Math.round(displayHeight),
     src,
     srcSet,
+    tracedSVG: defaultTracedSVG,
     width: Math.round(displayWidth),
   };
 };
@@ -112,6 +114,7 @@ exports.getFluidImageObject = async ({
   chained = [],
   cloudName,
   defaultBase64,
+  defaultTracedSVG,
   ignoreDefaultBase64 = false,
   maxWidth,
   originalHeight,
@@ -183,6 +186,7 @@ exports.getFluidImageObject = async ({
     sizes,
     src,
     srcSet,
+    tracedSVG: defaultTracedSVG,
   };
 };
 

--- a/packages/gatsby-transformer-cloudinary/get-image-objects.test.js
+++ b/packages/gatsby-transformer-cloudinary/get-image-objects.test.js
@@ -18,6 +18,7 @@ describe('getFluidImageObject', () => {
       cloudName: 'cloudName',
       originalWidth: 1920,
       originalHeight: 1080,
+      defaultTracedSVG: 'defaultTracedSVG',
       ...args,
     };
   }
@@ -77,6 +78,18 @@ describe('getFluidImageObject', () => {
     );
   });
 
+  it('returns a tracedSVG image', async () => {
+    const options = getDefaultOptions();
+    getPluginOptions.mockReturnValue(options);
+    const args = getDefaultArgs();
+
+    const expectedTracedSVG = args.defaultTracedSVG;
+
+    expect(await getFluidImageObject(args)).toEqual(
+      expect.objectContaining({ tracedSVG: expectedTracedSVG }),
+    );
+  });
+
   it('does not fetch base64 images multiple times', async () => {
     const options = getDefaultOptions();
     getPluginOptions.mockReturnValue(options);
@@ -94,9 +107,9 @@ describe('getFixedImageObject', () => {
     return {
       public_id: 'public_id',
       cloudName: 'cloudName',
-      // enableDefaultTranformations: true,
       originalWidth: 1920,
       originalHeight: 1080,
+      defaultTracedSVG: 'defaultTracedSVG',
       ...args,
     };
   }
@@ -225,6 +238,18 @@ describe('getFixedImageObject', () => {
 
     expect(await getFluidImageObject(args)).toEqual(
       expect.objectContaining({ base64: expectedBase64Image }),
+    );
+  });
+
+  it('returns a tracedSVG image', async () => {
+    const options = getDefaultOptions();
+    getPluginOptions.mockReturnValue(options);
+    const args = getDefaultArgs();
+
+    const expectedTracedSVG = args.defaultTracedSVG;
+
+    expect(await getFluidImageObject(args)).toEqual(
+      expect.objectContaining({ tracedSVG: expectedTracedSVG }),
     );
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2176,12 +2176,12 @@ axios@^0.19.0:
     follow-redirects "1.5.10"
     is-buffer "^2.0.2"
 
-axios@^0.19.2:
-  version "0.19.2"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.19.2.tgz#3ea36c5d8818d0d5f8a8a97a6d36b86cdc00cb27"
-  integrity sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==
+axios@^0.21.1:
+  version "0.21.1"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.1.tgz#22563481962f4d6bde9a76d516ef0e5d3c09b2b8"
+  integrity sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==
   dependencies:
-    follow-redirects "1.5.10"
+    follow-redirects "^1.10.0"
 
 axobject-query@^2.0.2:
   version "2.0.2"
@@ -5149,6 +5149,11 @@ follow-redirects@^1.0.0:
   version "1.13.0"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.13.0.tgz#b42e8d93a2a7eea5ed88633676d6597bc8e384db"
   integrity sha512-aq6gF1BEKje4a9i9+5jimNFIpq4Q1WiwBToeRK5NvZBd/TRsmW8BsJfOEGkr76TbOyPVD3OVDN910EcUNtRYEA==
+
+follow-redirects@^1.10.0:
+  version "1.13.2"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.13.2.tgz#dd73c8effc12728ba5cf4259d760ea5fb83e3147"
+  integrity sha512-6mPTgLxYm3r6Bkkg0vNM0HTjfGrOEtsfbhagQvbxDEsEkpNhw582upBaoRZylzen6krEmxXJgt9Ju6HiI4O7BA==
 
 for-in@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
This PR adds the ability to pass tracedSVG values from the user's CMS/backend through this plugin into Gatsby GraphQL queries. It also adds a few fragments to make querying for different types of placeholder images easier.