### PR TITLE
Lazy base64 evaluation

### DIFF
--- a/packages/gatsby-transformer-cloudinary/CHANGELOG.md
+++ b/packages/gatsby-transformer-cloudinary/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Version Next
 
+Fixes:
+
+- base64 images are no longer generated unless a query requesting them is run.
+
+# Version 2.1.1
+
 Additions:
 
 - Added logging for each time we have to fetch a base64 image from Cloudinary to explain long query steps in the Gatsby build process.

--- a/packages/gatsby-transformer-cloudinary/README.md
+++ b/packages/gatsby-transformer-cloudinary/README.md
@@ -171,6 +171,8 @@ The property `defaultBase64` in the node above can be used by your CMS/backend A
 
 When providing `defaultBase64` properties, it's recommended that you set the plugin option `alwaysUseDefaultBase64` to true in development. This may result in your base64 images looking different in development and production, but it will also result in much faster development build times as fewer API calls to Cloudinary will be made. The `alwaysUseDefaultBase64` plugin option overrides the `ignoreDefaultBase64` GraphQL query parameter and forces `gatsby-transformer-cloudinary` to always use `defaultBase64` images when they are provided.
 
+No API calls to Cloudinary for base64 images will be made if your GraphQL queries do not request base64 images.
+
 ### Plugin options
 
 In `gatsby-config.js` the plugin accepts the following options:

--- a/packages/gatsby-transformer-cloudinary/gatsby-node.js
+++ b/packages/gatsby-transformer-cloudinary/gatsby-node.js
@@ -53,7 +53,7 @@ exports.createSchemaCustomization = ({ actions }) => {
 
     type CloudinaryAssetFixed {
       aspectRatio: Float
-      base64: String!
+      base64: String
       height: Float
       src: String
       srcSet: String
@@ -63,7 +63,7 @@ exports.createSchemaCustomization = ({ actions }) => {
 
     type CloudinaryAssetFluid {
       aspectRatio: Float!
-      base64: String!
+      base64: String
       presentationHeight: Float
       presentationWidth: Float
       sizes: String!

--- a/packages/gatsby-transformer-cloudinary/gatsby-node.js
+++ b/packages/gatsby-transformer-cloudinary/gatsby-node.js
@@ -95,13 +95,19 @@ exports.createResolvers = ({ createResolvers, reporter }) => {
             transformations,
             chained,
           },
-        ) =>
-          getFixedImageObject({
+          _context,
+          info,
+        ) => {
+          const fieldsToSelect = info.fieldNodes[0].selectionSet.selections.map(
+            item => item.name.value,
+          );
+          return getFixedImageObject({
             base64Transformations,
             base64Width,
             chained,
             cloudName,
             defaultBase64,
+            fieldsToSelect,
             height,
             ignoreDefaultBase64,
             originalHeight,
@@ -111,7 +117,8 @@ exports.createResolvers = ({ createResolvers, reporter }) => {
             transformations,
             version,
             width,
-          }),
+          });
+        },
       },
       fluid: {
         type: 'CloudinaryAssetFluid!',
@@ -133,14 +140,20 @@ exports.createResolvers = ({ createResolvers, reporter }) => {
             maxWidth,
             transformations,
           },
-        ) =>
-          getFluidImageObject({
+          _context,
+          info,
+        ) => {
+          const fieldsToSelect = info.fieldNodes[0].selectionSet.selections.map(
+            item => item.name.value,
+          );
+          return getFluidImageObject({
             base64Transformations,
             base64Width,
             breakpoints,
             chained,
             cloudName,
             defaultBase64,
+            fieldsToSelect,
             ignoreDefaultBase64,
             maxWidth,
             originalHeight,
@@ -149,7 +162,8 @@ exports.createResolvers = ({ createResolvers, reporter }) => {
             reporter,
             transformations,
             version,
-          }),
+          });
+        },
       },
     },
   };

--- a/packages/gatsby-transformer-cloudinary/get-image-objects.js
+++ b/packages/gatsby-transformer-cloudinary/get-image-objects.js
@@ -16,6 +16,7 @@ exports.getFixedImageObject = async ({
   chained = [],
   cloudName,
   defaultBase64,
+  fieldsToSelect,
   height,
   ignoreDefaultBase64 = false,
   originalHeight,
@@ -26,19 +27,6 @@ exports.getFixedImageObject = async ({
   version = false,
   width,
 }) => {
-  const base64 = await getBase64({
-    base64Transformations,
-    base64Width,
-    chained,
-    cloudName,
-    defaultBase64,
-    ignoreDefaultBase64,
-    public_id,
-    reporter,
-    transformations,
-    version,
-  });
-
   const src = getImageURL({
     public_id,
     version,
@@ -96,13 +84,29 @@ exports.getFixedImageObject = async ({
     })
     .join();
 
-  return {
-    base64,
+  const fixedImageObject = {
     height: Math.round(displayHeight),
     src,
     srcSet,
     width: Math.round(displayWidth),
   };
+
+  if (fieldsToSelect.includes('base64')) {
+    fixedImageObject.base64 = await getBase64({
+      base64Transformations,
+      base64Width,
+      chained,
+      cloudName,
+      defaultBase64,
+      ignoreDefaultBase64,
+      public_id,
+      reporter,
+      transformations,
+      version,
+    });
+  }
+
+  return fixedImageObject;
 };
 
 exports.getFluidImageObject = async ({
@@ -112,6 +116,7 @@ exports.getFluidImageObject = async ({
   chained = [],
   cloudName,
   defaultBase64,
+  fieldsToSelect,
   ignoreDefaultBase64 = false,
   maxWidth,
   originalHeight,
@@ -128,18 +133,6 @@ exports.getFluidImageObject = async ({
   const { fluidMaxWidth } = getPluginOptions();
   const max = Math.min(maxWidth ? maxWidth : fluidMaxWidth, originalWidth);
   const sizes = `(max-width: ${max}px) 100vw, ${max}px`;
-  const base64 = await getBase64({
-    base64Transformations,
-    base64Width,
-    chained,
-    cloudName,
-    defaultBase64,
-    ignoreDefaultBase64,
-    public_id,
-    reporter,
-    transformations,
-    version,
-  });
   const src = getImageURL({
     public_id,
     version,
@@ -175,15 +168,31 @@ exports.getFluidImageObject = async ({
     (presentationWidth * originalHeight) / originalWidth,
   );
 
-  return {
+  const fluidImageObject = {
     aspectRatio,
-    base64,
     presentationWidth,
     presentationHeight,
     sizes,
     src,
     srcSet,
   };
+
+  if (fieldsToSelect.includes('base64')) {
+    fluidImageObject.base64 = await getBase64({
+      base64Transformations,
+      base64Width,
+      chained,
+      cloudName,
+      defaultBase64,
+      ignoreDefaultBase64,
+      public_id,
+      reporter,
+      transformations,
+      version,
+    });
+  }
+
+  return fluidImageObject;
 };
 
 function onlyUnique(element, index, array) {

--- a/packages/gatsby-transformer-cloudinary/get-image-objects.test.js
+++ b/packages/gatsby-transformer-cloudinary/get-image-objects.test.js
@@ -85,6 +85,7 @@ describe('getFluidImageObject', () => {
     const args = getDefaultArgs({ fieldsToSelect: [] });
 
     expect((await getFluidImageObject(args)).base64).toEqual(undefined);
+  });
 
   it('returns a tracedSVG image', async () => {
     const options = getDefaultOptions();
@@ -257,6 +258,7 @@ describe('getFixedImageObject', () => {
     const args = getDefaultArgs({ fieldsToSelect: [] });
 
     expect((await getFluidImageObject(args)).base64).toEqual(undefined);
+  });
 
   it('returns a tracedSVG image', async () => {
     const options = getDefaultOptions();

--- a/packages/gatsby-transformer-cloudinary/get-image-objects.test.js
+++ b/packages/gatsby-transformer-cloudinary/get-image-objects.test.js
@@ -18,6 +18,7 @@ describe('getFluidImageObject', () => {
       cloudName: 'cloudName',
       originalWidth: 1920,
       originalHeight: 1080,
+      fieldsToSelect: ['base64'],
       ...args,
     };
   }
@@ -77,6 +78,14 @@ describe('getFluidImageObject', () => {
     );
   });
 
+  it('does not return base64 if base64 is not a field to select', async () => {
+    const options = getDefaultOptions();
+    getPluginOptions.mockReturnValue(options);
+    const args = getDefaultArgs({ fieldsToSelect: [] });
+
+    expect((await getFluidImageObject(args)).base64).toEqual(undefined);
+  });
+
   it('does not fetch base64 images multiple times', async () => {
     const options = getDefaultOptions();
     getPluginOptions.mockReturnValue(options);
@@ -97,6 +106,7 @@ describe('getFixedImageObject', () => {
       // enableDefaultTranformations: true,
       originalWidth: 1920,
       originalHeight: 1080,
+      fieldsToSelect: ['base64'],
       ...args,
     };
   }
@@ -226,6 +236,14 @@ describe('getFixedImageObject', () => {
     expect(await getFluidImageObject(args)).toEqual(
       expect.objectContaining({ base64: expectedBase64Image }),
     );
+  });
+
+  it('does not return base64 if base64 is not a field to select', async () => {
+    const options = getDefaultOptions();
+    getPluginOptions.mockReturnValue(options);
+    const args = getDefaultArgs({ fieldsToSelect: [] });
+
+    expect((await getFluidImageObject(args)).base64).toEqual(undefined);
   });
 
   it('does not fetch base64 images multiple times', async () => {


### PR DESCRIPTION
This PR makes it so that Cloudinary API calls for base64 images are only run if the user requests a base64 image with their GraphQL query. For users who do not use base64 images, this will result in much fast builds.