### PR TITLE
Improve base64 caching

### DIFF
--- a/packages/gatsby-transformer-cloudinary/CHANGELOG.md
+++ b/packages/gatsby-transformer-cloudinary/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Version Next
 
+Fixes:
+
+- Improved base64 caching so that if a second request for the same base64 image is made before the first response is received, only one request is made.
+
+# Version 2.1.1
+
 Additions:
 
 - Added logging for each time we have to fetch a base64 image from Cloudinary to explain long query steps in the Gatsby build process.

--- a/packages/gatsby-transformer-cloudinary/get-image-objects/get-shared-image-data.js
+++ b/packages/gatsby-transformer-cloudinary/get-image-objects/get-shared-image-data.js
@@ -85,12 +85,11 @@ exports.getBase64 = async ({
 async function fetchBase64(url, reporter) {
   if (!base64Cache[url]) {
     logBase64Retrieval(url, reporter);
-    const result = await axios.get(url, { responseType: 'arraybuffer' });
-    const data = Buffer.from(result.data).toString('base64');
-    base64Cache[url] = `data:image/jpeg;base64,${data}`;
+    base64Cache[url] = axios.get(url, { responseType: 'arraybuffer' });
   }
-
-  return base64Cache[url];
+  const response = await base64Cache[url];
+  const data = Buffer.from(response.data).toString('base64');
+  return `data:image/jpeg;base64,${data}`;
 }
 
 let fetchedBase64ImageCount = 0;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2176,12 +2176,12 @@ axios@^0.19.0:
     follow-redirects "1.5.10"
     is-buffer "^2.0.2"
 
-axios@^0.19.2:
-  version "0.19.2"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.19.2.tgz#3ea36c5d8818d0d5f8a8a97a6d36b86cdc00cb27"
-  integrity sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==
+axios@^0.21.1:
+  version "0.21.1"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.1.tgz#22563481962f4d6bde9a76d516ef0e5d3c09b2b8"
+  integrity sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==
   dependencies:
-    follow-redirects "1.5.10"
+    follow-redirects "^1.10.0"
 
 axobject-query@^2.0.2:
   version "2.0.2"
@@ -5149,6 +5149,11 @@ follow-redirects@^1.0.0:
   version "1.13.0"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.13.0.tgz#b42e8d93a2a7eea5ed88633676d6597bc8e384db"
   integrity sha512-aq6gF1BEKje4a9i9+5jimNFIpq4Q1WiwBToeRK5NvZBd/TRsmW8BsJfOEGkr76TbOyPVD3OVDN910EcUNtRYEA==
+
+follow-redirects@^1.10.0:
+  version "1.13.2"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.13.2.tgz#dd73c8effc12728ba5cf4259d760ea5fb83e3147"
+  integrity sha512-6mPTgLxYm3r6Bkkg0vNM0HTjfGrOEtsfbhagQvbxDEsEkpNhw582upBaoRZylzen6krEmxXJgt9Ju6HiI4O7BA==
 
 for-in@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
This PR improves base64 image caching.

Previously, the base64 cache was updated after the base64 image was received from Cloudinary. If a second request for the image was made before the response came back, then a second API call to Cloudinary would be made.

Now, the promise for the API call is cached instead of the resolved image. This means the cache is updated immediately, and all requests for the same image will resolve from the same promise.