### PR TITLE
Add publicId to CloudinaryAsset

### DIFF
--- a/packages/gatsby-transformer-cloudinary/create-image-node.js
+++ b/packages/gatsby-transformer-cloudinary/create-image-node.js
@@ -71,6 +71,9 @@ exports.createImageNode = ({
     defaultBase64,
     defaultTracedSVG,
 
+    // These fields will be available via Gatsby's data layer
+    publicId: public_id,
+
     // Add the required internal Gatsby node fields.
     id: createNodeId(`CloudinaryAsset-${fingerprint}`),
     parent: parentNode.id,

--- a/packages/gatsby-transformer-cloudinary/gatsby-node.js
+++ b/packages/gatsby-transformer-cloudinary/gatsby-node.js
@@ -31,6 +31,8 @@ exports.onPreExtractQueries = async ({ store, getNodesByType }) => {
 exports.createSchemaCustomization = ({ actions }) => {
   actions.createTypes(`
     type CloudinaryAsset implements Node @dontInfer {
+      publicId: String!
+
       fixed(
         base64Width: Int
         base64Transformations: [String!]


### PR DESCRIPTION
This PR includes the original public_id value on the new CloudinaryAsset GQL type.

Closes #89.