### PR TITLE
feat(site): add existing data examples

### DIFF
--- a/site/gatsby-node.js
+++ b/site/gatsby-node.js
@@ -1,0 +1,44 @@
+exports.sourceNodes = (gatsbyUtils) => {
+  const { actions, reporter, createNodeId, createContentDigest } = gatsbyUtils;
+  const { createNode } = actions;
+
+  const cloudinaryData1 = {
+    cloudinaryAssetData: true,
+    cloudName: 'lilly-labs-consulting',
+    publicId: 'sample',
+    originalHeight: 576,
+    originalWidth: 864,
+  };
+
+  createNode({
+    id: createNodeId(`ExistingData >>> 1`),
+    name: 'Existing data 1',
+    exampleImage: cloudinaryData1,
+    internal: {
+      type: 'ExistingData',
+      contentDigest: createContentDigest(cloudinaryData1),
+    },
+  });
+
+  reporter.info(`[site] Create ExistingData node # 1`);
+
+  const cloudinaryData2 = {
+    cloudinaryAssetData: true,
+    cloudName: 'jlengstorf',
+    publicId: 'gatsby-cloudinary/jason',
+    originalHeight: 3024,
+    originalWidth: 4032,
+  };
+
+  createNode({
+    id: createNodeId(`ExistingData >>> 2`),
+    name: 'Existing data 2',
+    exampleImage: cloudinaryData2,
+    internal: {
+      type: 'ExistingData',
+      contentDigest: createContentDigest(cloudinaryData2),
+    },
+  });
+
+  reporter.info(`[site] Create ExistingData node # 2`);
+};

--- a/site/src/components/header.js
+++ b/site/src/components/header.js
@@ -25,6 +25,9 @@ const Header = ({ siteTitle }) => (
       <Link to="/manual/" activeClassName="active">
         Manual
       </Link>
+      <Link to="/existing/" activeClassName="active">
+        Existing
+      </Link>
       <a href="https://www.npmjs.com/package/gatsby-transformer-cloudinary#install">
         Install
       </a>

--- a/site/src/examples/existing-data-1.js
+++ b/site/src/examples/existing-data-1.js
@@ -1,0 +1,62 @@
+import React from 'react';
+import { graphql, useStaticQuery } from 'gatsby';
+import Image from 'gatsby-image';
+
+const ExistingData1 = () => {
+  const data = useStaticQuery(graphql`
+    query {
+      existingData(name: { eq: "Existing data 1" }) {
+        cloudinary: exampleImage {
+          fixed(height: 300, width: 300, transformations: ["c_fill"]) {
+            ...CloudinaryAssetFixed
+          }
+        }
+      }
+    }
+  `);
+
+  // Duplicate the query so we can display it on the page.
+  const query = `
+    query {
+      existingData(name: { eq: "Existing data 1" }) {
+        cloudinary: exampleImage {
+          fixed(height: 300, width: 300, transformations: ["c_fill"]) {
+            ...CloudinaryAssetFixed
+          }
+        }
+      }
+    }
+  `
+    .replace(/^ {4}/gm, '') // Remove the leading indentation (this is a hack).
+    .trim();
+
+  const nodeData = JSON.stringify(
+    {
+      exampleImage: {
+        cloudinaryAssetData: true,
+        cloudName: 'lilly-labs-consulting',
+        publicId: 'sample',
+        originalHeight: 576,
+        originalWidth: 864,
+      },
+    },
+    null,
+    2
+  );
+
+  return (
+    <div className="image-example">
+      <h2>Example 1</h2>
+      <Image
+        fixed={data.existingData.cloudinary.fixed}
+        alt="Jason giving finger guns toward the camera."
+      />
+      <h3>Query</h3>
+      <pre>{query}</pre>
+      <h3>Data</h3>
+      <pre>{nodeData}</pre>
+    </div>
+  );
+};
+
+export default ExistingData1;

--- a/site/src/examples/existing-data-2.js
+++ b/site/src/examples/existing-data-2.js
@@ -1,0 +1,62 @@
+import React from 'react';
+import { graphql, useStaticQuery } from 'gatsby';
+import Image from 'gatsby-image';
+
+const ExistingData2 = () => {
+  const data = useStaticQuery(graphql`
+    query {
+      existingData(name: { eq: "Existing data 2" }) {
+        cloudinary: exampleImage {
+          fixed(height: 300, width: 300, transformations: ["c_fill"]) {
+            ...CloudinaryAssetFixed
+          }
+        }
+      }
+    }
+  `);
+
+  // Duplicate the query so we can display it on the page.
+  const query = `
+    query {
+      existingData(name: { eq: "Existing data 2" }) {
+        cloudinary: exampleImage {
+          fixed(height: 300, width: 300, transformations: ["c_fill"]) {
+            ...CloudinaryAssetFixed
+          }
+        }
+      }
+    }
+  `
+    .replace(/^ {4}/gm, '') // Remove the leading indentation (this is a hack).
+    .trim();
+
+  const nodeData = JSON.stringify(
+    {
+      exampleImage: {
+        cloudinaryAssetData: true,
+        cloudName: 'jlengstorf',
+        publicId: 'gatsby-cloudinary/jason',
+        originalHeight: 3024,
+        originalWidth: 4032,
+      },
+    },
+    null,
+    2
+  );
+
+  return (
+    <div className="image-example">
+      <h2>Example 2</h2>
+      <Image
+        fixed={data.existingData.cloudinary.fixed}
+        alt="Jason giving finger guns toward the camera."
+      />
+      <h3>Query</h3>
+      <pre>{query}</pre>
+      <h3>Data</h3>
+      <pre>{nodeData}</pre>
+    </div>
+  );
+};
+
+export default ExistingData2;

--- a/site/src/pages/existing.js
+++ b/site/src/pages/existing.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import Layout from '../components/layout';
+import ExistingData1 from '../examples/existing-data-1';
+import ExistingData2 from '../examples/existing-data-2';
+
+const ExistingPage = () => (
+  <Layout>
+    <h1>Node with Existing Data</h1>
+    <p>
+      It's possible to use existing Cloudinary assets, as opposed to uploading
+      local files.
+    </p>
+    <div className="examples">
+      <ExistingData1 />
+      <ExistingData2 />
+    </div>
+  </Layout>
+);
+
+export default ExistingPage;


### PR DESCRIPTION
The Gatsby v4 support issues (#139) are related to the use of existing data. 
This PR adds existing data examples to the demo site to showcase a working example that will break when the site is upgraded to v4.