### PR TITLE
refactor: create types

### DIFF
--- a/packages/gatsby-transformer-cloudinary/gatsby-image/index.js
+++ b/packages/gatsby-transformer-cloudinary/gatsby-image/index.js
@@ -31,6 +31,15 @@ exports.createGatsbyImageResolvers = ({ createResolvers, reporter }) => {
     CloudinaryAsset: {
       fixed: {
         type: 'CloudinaryAssetFixed!',
+        args: {
+          base64Width: 'Int',
+          base64Transformations: '[String!]',
+          chained: '[String!]',
+          height: 'Int',
+          transformations: '[String!]',
+          width: 'Int',
+          ignoreDefaultBase64: 'Boolean',
+        },
         resolve: (source, args, _context, info) => {
           const fieldsToSelect = info.fieldNodes[0].selectionSet.selections.map(
             (item) => item.name.value
@@ -46,6 +55,14 @@ exports.createGatsbyImageResolvers = ({ createResolvers, reporter }) => {
       },
       fluid: {
         type: 'CloudinaryAssetFluid!',
+        args: {
+          base64Width: 'Int',
+          base64Transformations: '[String!]',
+          chained: '[String!]',
+          maxWidth: 'Int',
+          transformations: '[String!]',
+          ignoreDefaultBase64: 'Boolean',
+        },
         resolve: (source, args, _context, info) => {
           const fieldsToSelect = info.fieldNodes[0].selectionSet.selections.map(
             (item) => item.name.value

--- a/packages/gatsby-transformer-cloudinary/gatsby-image/types.js
+++ b/packages/gatsby-transformer-cloudinary/gatsby-image/types.js
@@ -1,29 +1,4 @@
 exports.gatsbyImageTypes = `
-    type CloudinaryAsset implements Node @dontInfer  {
-      publicId: String!
-      cloudName: String!
-      version: String
-
-      fixed(
-        base64Width: Int
-        base64Transformations: [String!]
-        chained: [String!]
-        height: Int
-        transformations: [String!]
-        width: Int
-        ignoreDefaultBase64: Boolean
-      ): CloudinaryAssetFixed!
-
-      fluid(
-        base64Width: Int
-        base64Transformations: [String!]
-        chained: [String!]
-        maxWidth: Int
-        transformations: [String!]
-        ignoreDefaultBase64: Boolean
-      ): CloudinaryAssetFluid!
-    }
-
     type CloudinaryAssetFixed {
       aspectRatio: Float
       base64: String

--- a/packages/gatsby-transformer-cloudinary/gatsby-node.js
+++ b/packages/gatsby-transformer-cloudinary/gatsby-node.js
@@ -1,7 +1,7 @@
 const { setPluginOptions, getPluginOptions } = require('./options');
 const {
-  createAssetNodesFromData,
-  createAssetNodeFromFile,
+  createCloudinaryAssetType,
+  createCloudinaryAssetNodes,
 } = require('./node-creation');
 const {
   createGatsbyImageResolvers,
@@ -46,25 +46,20 @@ exports.onPreExtractQueries = async (gatsbyUtils) => {
 };
 
 exports.createSchemaCustomization = (gatsbyUtils) => {
+  // Type to be used for node creation
+  createCloudinaryAssetType(gatsbyUtils);
+
   // Types to be used with gatsby-image
   createGatsbyImageTypes(gatsbyUtils);
 };
 
 exports.createResolvers = (gatsbyUtils) => {
+  const { reporter } = gatsbyUtils;
   // Resolvers to be used with gatsby-image
   createGatsbyImageResolvers(gatsbyUtils);
 };
 
 exports.onCreateNode = async (gatsbyUtils) => {
-  // Create nodes from existing cloudinary data
-  createAssetNodesFromData(gatsbyUtils);
-
-  // Create nodes for files to be uploaded to cloudinary
-  if (
-    pluginOptions.apiKey &&
-    pluginOptions.apiSecret &&
-    pluginOptions.cloudName
-  ) {
-    await createAssetNodeFromFile(gatsbyUtils, pluginOptions);
-  }
+  // Create Cloudinary Asset nodes if applicable
+  await createCloudinaryAssetNodes(gatsbyUtils, pluginOptions);
 };

--- a/packages/gatsby-transformer-cloudinary/node-creation/index.js
+++ b/packages/gatsby-transformer-cloudinary/node-creation/index.js
@@ -1,7 +1,23 @@
 const { createAssetNodesFromData } = require('./create-asset-nodes-from-data');
 const { createAssetNodeFromFile } = require('./create-asset-node-from-file');
 
-module.exports = {
-  createAssetNodesFromData,
-  createAssetNodeFromFile,
+const { CloudinaryAssetType } = require('./types');
+
+exports.createCloudinaryAssetType = (gatsbyUtils) => {
+  const { actions } = gatsbyUtils;
+  actions.createTypes(CloudinaryAssetType);
+};
+
+exports.createCloudinaryAssetNodes = async (gatsbyUtils, pluginOptions) => {
+  // Create nodes from existing cloudinary data
+  createAssetNodesFromData(gatsbyUtils);
+
+  // Create nodes for files to be uploaded to cloudinary
+  if (
+    pluginOptions.apiKey &&
+    pluginOptions.apiSecret &&
+    pluginOptions.cloudName
+  ) {
+    await createAssetNodeFromFile(gatsbyUtils, pluginOptions);
+  }
 };

--- a/packages/gatsby-transformer-cloudinary/node-creation/types.js
+++ b/packages/gatsby-transformer-cloudinary/node-creation/types.js
@@ -1,0 +1,7 @@
+exports.CloudinaryAssetType = `
+  type CloudinaryAsset implements Node @dontInfer  {
+    publicId: String!
+    cloudName: String!
+    version: String
+  }
+`;


### PR DESCRIPTION
- Move create CloudinaryAsset type from gatsby-image to node-creation  module