### PR TITLE
refactor: remove upload code only needed by gatsby-image

### DIFF
--- a/plugin/node-creation/upload.js
+++ b/plugin/node-creation/upload.js
@@ -13,17 +13,9 @@ exports.uploadImageToCloudinary = async ({
   reporter,
 }) => {
   verifyRequiredOptions(reporter);
-  const {
-    apiKey,
-    apiSecret,
-    breakpointsMaxImages,
-    cloudName,
-    createDerived,
-    fluidMaxWidth,
-    fluidMinWidth,
-    uploadFolder,
-    useCloudinaryBreakpoints,
-  } = getPluginOptions();
+
+  const { apiKey, apiSecret, cloudName, uploadFolder } = getPluginOptions();
+
   cloudinary.config({
     cloud_name: cloudName,
     api_key: apiKey,
@@ -37,26 +29,6 @@ exports.uploadImageToCloudinary = async ({
     resource_type: 'auto',
     timeout: FIVE_MINUTES,
   };
-
-  // Each time we ask Cloudinary to calculate the responsive breakpoints for an
-  // image, Cloudinary bills us for one transformation. Since this API call
-  // gets called for every image every time our Gatsby cache gets cleared, this
-  // can get expensive very fast. This option should not be used outside of
-  // production. It's recommended that createDerived be set to true when
-  // useCloudinaryBreakpoints is set to true.This will store the derived images
-  // and prevent Cloudinary from using more transformations to recompute them
-  // in the future.
-  if (useCloudinaryBreakpoints) {
-    uploadOptions.responsive_breakpoints = [
-      {
-        create_derived: createDerived,
-        bytes_step: 20000,
-        min_width: fluidMinWidth,
-        max_width: fluidMaxWidth,
-        max_images: breakpointsMaxImages,
-      },
-    ];
-  }
 
   let attempts = 1;
 

--- a/plugin/node-creation/upload.test.js
+++ b/plugin/node-creation/upload.test.js
@@ -37,9 +37,6 @@ describe('uploadImageToCloudinary', () => {
       apiSecret: 'apiSecret',
       uploadFolder: 'uploadFolder',
       createDerived: false,
-      breakpointsMaxImages: 234,
-      fluidMaxWidth: 345,
-      fluidMinWidth: 456,
       ...options,
     };
   }
@@ -62,27 +59,6 @@ describe('uploadImageToCloudinary', () => {
     expect(cloudinaryConfig).toHaveBeenCalledWith(expected);
   });
 
-  it('does not ask for responsive breakpoints when useCloudinaryBreakpoints is false', async () => {
-    const cloudinaryUpload = jest.fn();
-    cloudinary.uploader.upload = cloudinaryUpload;
-
-    const options = getDefaultOptions({ useCloudinaryBreakpoints: false });
-    getPluginOptions.mockReturnValue(options);
-
-    const args = getDefaultArgs();
-    await uploadImageToCloudinary(args);
-
-    const expectedUrl = args.url;
-    const expectedOptions = {
-      folder: options.uploadFolder,
-      overwrite: args.overwrite,
-      public_id: args.publicId,
-      resource_type: 'auto',
-      timeout: 5 * 60 * 1000,
-    };
-    expect(cloudinaryUpload).toHaveBeenCalledWith(expectedUrl, expectedOptions);
-  });
-
   it('overwrites when passed overwrite:true', async () => {
     const cloudinaryUpload = jest.fn();
     cloudinary.uploader.upload = cloudinaryUpload;
@@ -100,39 +76,6 @@ describe('uploadImageToCloudinary', () => {
       public_id: args.publicId,
       resource_type: 'auto',
       timeout: 5 * 60 * 1000,
-    };
-    expect(cloudinaryUpload).toHaveBeenCalledWith(expectedUrl, expectedOptions);
-  });
-
-  it('asks for responsive breakpoints when useCloudinaryBreakpoints is true', async () => {
-    const cloudinaryUpload = jest.fn();
-    cloudinary.uploader.upload = cloudinaryUpload;
-
-    const options = getDefaultOptions({
-      useCloudinaryBreakpoints: true,
-      createDerived: 'createDerived',
-    });
-    getPluginOptions.mockReturnValue(options);
-
-    const args = getDefaultArgs();
-    await uploadImageToCloudinary(args);
-
-    const expectedUrl = args.url;
-    const expectedOptions = {
-      folder: options.uploadFolder,
-      overwrite: args.overwrite,
-      public_id: args.publicId,
-      resource_type: 'auto',
-      timeout: 5 * 60 * 1000,
-      responsive_breakpoints: [
-        {
-          bytes_step: 20000,
-          create_derived: options.createDerived,
-          max_images: options.breakpointsMaxImages,
-          max_width: options.fluidMaxWidth,
-          min_width: options.fluidMinWidth,
-        },
-      ],
     };
     expect(cloudinaryUpload).toHaveBeenCalledWith(expectedUrl, expectedOptions);
   });

--- a/plugin/options.js
+++ b/plugin/options.js
@@ -3,14 +3,8 @@ const { isArray } = require('lodash');
 let options = {};
 
 const defaultOptions = {
-  fluidMaxWidth: 1000,
-  fluidMinWidth: 50,
   breakpointsMaxImages: 20,
-  createDerived: false,
-  useCloudinaryBreakpoints: false,
   overwriteExisting: false,
-  enableDefaultTransformations: false,
-  alwaysUseDefaultBase64: false,
   defaultTransformations: ['c_fill', 'g_auto', 'q_auto'],
   transformTypes: ['CloudinaryAsset'],
 };


### PR DESCRIPTION
Part of #188 since there was breakpoint optimization done on upload for gatsby-image that is no longer in use.