### PR TITLE
fix: problem getting metadata

### DIFF
--- a/demo/gatsby-config.js
+++ b/demo/gatsby-config.js
@@ -31,6 +31,7 @@ module.exports = {
           'ArticleFeatureImage',
           'BlogPostHeroImage',
           'VariedData',
+          'EmptyDataCloudinary',
         ],
       },
     },

--- a/demo/gatsby-config.js
+++ b/demo/gatsby-config.js
@@ -30,7 +30,7 @@ module.exports = {
           'CloudinaryAsset',
           'ArticleFeatureImage',
           'BlogPostHeroImage',
-          'SomeBadImageData',
+          'VariedData',
         ],
       },
     },

--- a/demo/gatsby-node.js
+++ b/demo/gatsby-node.js
@@ -115,6 +115,69 @@ exports.sourceNodes = (gatsbyUtils) => {
     `[site] Create SomeBadImageData with gif asset without metadata`
   );
 
+  const existingPdfWithoutMetadata = {
+    cloudName: 'lilly-labs-consulting',
+    publicId: 'diverse%20mime%20types/en-US-YearCompass-booklet.pdf',
+  };
+
+  createNode({
+    id: createNodeId(`SomeBadImageData >>> 7`),
+    name: 'ExistingPDFWithoutMetadata',
+    ...existingPdfWithoutMetadata,
+    internal: {
+      type: 'SomeBadImageData',
+      contentDigest: createContentDigest(existingPdfWithoutMetadata),
+    },
+  });
+
+  reporter.info(
+    `[site] Create SomeBadImageData with pdf asset without metadata`
+  );
+
+  const existingPdfWithPDFMetadata = {
+    cloudName: 'lilly-labs-consulting',
+    publicId: 'diverse%20mime%20types/en-US-YearCompass-booklet.pdf',
+    originalWidth: 1650,
+    originalHeight: 1275,
+    originalFormat: 'pdf',
+  };
+
+  createNode({
+    id: createNodeId(`SomeBadImageData >>> 8`),
+    name: 'ExistingPdfWithPDFMetadata',
+    ...existingPdfWithPDFMetadata,
+    internal: {
+      type: 'SomeBadImageData',
+      contentDigest: createContentDigest(existingPdfWithPDFMetadata),
+    },
+  });
+
+  reporter.info(
+    `[site] Create SomeBadImageData with pdf asset with pdf metadata`
+  );
+
+  const existingPdfWithPNGMetadata = {
+    cloudName: 'lilly-labs-consulting',
+    publicId: 'diverse%20mime%20types/en-US-YearCompass-booklet.pdf',
+    originalWidth: 1650,
+    originalHeight: 1275,
+    originalFormat: 'png',
+  };
+
+  createNode({
+    id: createNodeId(`SomeBadImageData >>> 9`),
+    name: 'ExistingPdfWithPNGMetadata',
+    ...existingPdfWithPNGMetadata,
+    internal: {
+      type: 'SomeBadImageData',
+      contentDigest: createContentDigest(existingPdfWithPNGMetadata),
+    },
+  });
+
+  reporter.info(
+    `[site] Create SomeBadImageData with pdf asset with png metadata`
+  );
+
   const blogPostData1 = {
     title: 'Blog Post Example One',
     slug: 'post-1',

--- a/demo/gatsby-node.js
+++ b/demo/gatsby-node.js
@@ -6,182 +6,168 @@ exports.sourceNodes = (gatsbyUtils) => {
     gatsbyUtils;
   const { createNode } = actions;
 
-  const existingAssetsWithoutMetadata = {
+  const variedData = [
+    {
+      name: 'No assed info',
+      expected: 'No image',
+    },
+    {
+      name: 'Non existing asset without metadata',
+      expected: 'No image',
+      cloudName: 'not-a-good-cloudName',
+      publicId: 'sample',
+    },
+    {
+      name: 'Non existing asset with metadata',
+      expected: 'Broken image',
+      cloudName: 'not-a-good-cloudName',
+      publicId: 'sample',
+      originalHeight: 400,
+      originalWidth: 300,
+      originalFormat: 'png',
+    },
+    {
+      name: 'Asset without metadata',
+      expected: 'Rastered image',
+      cloudName: 'lilly-labs-consulting',
+      publicId: 'sample',
+    },
+    {
+      name: 'Asset with metadata',
+      expected: 'Rastered image',
+      cloudName: 'lilly-labs-consulting',
+      publicId: 'sample',
+      originalWidth: 864,
+      originalHeight: 576,
+      originalFormat: 'jpg',
+    },
+    {
+      name: 'Video without metadata',
+      expected: 'No image - in future: rastered image ',
+      cloudName: 'lilly-labs-consulting',
+      publicId: 'diverse mime types/chop-chop-video.mp4',
+    },
+    {
+      name: 'Video with metadata',
+      expected: 'Broken image - in future: rastered image ',
+      cloudName: 'lilly-labs-consulting',
+      publicId: 'diverse mime types/chop-chop-video.mp4',
+      originalHeight: 1800,
+      originalWidth: 1800,
+      originalFormat: 'mp4',
+    },
+    {
+      name: 'Video with metadata - jpg',
+      expected: 'Broken image - in future: rastered image ',
+      cloudName: 'lilly-labs-consulting',
+      publicId: 'diverse mime types/chop-chop-video.mp4',
+      originalHeight: 1800,
+      originalWidth: 1800,
+      originalFormat: 'jpg',
+    },
+    {
+      name: 'Gif without metadata',
+      expected: 'Animated image',
+      cloudName: 'lilly-labs-consulting',
+      publicId: 'diverse%20mime%20types/giphyCat.gif',
+    },
+    {
+      name: 'Gif with metdata',
+      expected: 'Animated image',
+      cloudName: 'lilly-labs-consulting',
+      publicId: 'diverse%20mime%20types/giphyCat.gif',
+      originalWidth: 480,
+      originalHeight: 315,
+      originalFormat: 'gif',
+    },
+    {
+      name: 'Gif with metdata - png',
+      expected: 'Animated image',
+      cloudName: 'lilly-labs-consulting',
+      publicId: 'diverse%20mime%20types/giphyCat.gif',
+      originalWidth: 480,
+      originalHeight: 315,
+      // Wrong original format
+      originalFormat: 'png',
+    },
+    {
+      name: 'Pdf without metadata',
+      expected: 'Rastered image of first page',
+      cloudName: 'lilly-labs-consulting',
+      publicId: 'diverse%20mime%20types/en-US-YearCompass-booklet.pdf',
+    },
+    {
+      name: 'Pdf with metadata',
+      expected: 'Rastered image of first page',
+      cloudName: 'lilly-labs-consulting',
+      publicId: 'diverse%20mime%20types/en-US-YearCompass-booklet.pdf',
+      originalWidth: 1650,
+      originalHeight: 1275,
+      originalFormat: 'pdf',
+    },
+    {
+      name: 'Pdf with metadata - jpg',
+      expected: 'Rastered image of first page',
+      cloudName: 'lilly-labs-consulting',
+      publicId: 'diverse%20mime%20types/en-US-YearCompass-booklet.pdf',
+      originalWidth: 1650,
+      originalHeight: 1275,
+      // Wrong original format
+      originalFormat: 'jpg',
+    },
+    {
+      name: 'Svg without metdata',
+      expected: 'Rastered image',
+      cloudName: 'lilly-labs-consulting',
+      publicId: 'diverse%20mime%20types/bubble-gum-ice-skating.svg',
+    },
+    {
+      name: 'Svg with metdata',
+      expected: 'Rastered image',
+      cloudName: 'lilly-labs-consulting',
+      publicId: 'diverse%20mime%20types/bubble-gum-ice-skating.svg',
+      originalHeight: 3000,
+      originalWidth: 3000,
+      originalFormat: 'svg',
+    },
+    {
+      name: 'Svg with metdata - png',
+      expected: 'Rastered image',
+      cloudName: 'lilly-labs-consulting',
+      publicId: 'diverse%20mime%20types/bubble-gum-ice-skating.svg',
+      originalHeight: 3000,
+      originalWidth: 3000,
+      // Wrong original format
+      originalFormat: 'png',
+    },
+  ];
+
+  variedData.forEach((asset, key) => {
+    createNode({
+      id: createNodeId(`VariedData >>> ${key}`),
+      ...asset,
+      internal: {
+        type: 'VariedData',
+        contentDigest: createContentDigest(asset),
+      },
+    });
+
+    reporter.info(`[site] Create VariedData: ${asset.name}`);
+  });
+
+  const sampleAsset = {
+    name: 'Asset with metadata',
     cloudName: 'lilly-labs-consulting',
     publicId: 'sample',
+    originalWidth: 864,
+    originalHeight: 576,
+    originalFormat: 'jpg',
   };
-
-  createNode({
-    id: createNodeId(`SomeBadImageData >>> 1`),
-    name: 'GoodData',
-    ...existingAssetsWithoutMetadata,
-    internal: {
-      type: 'SomeBadImageData',
-      contentDigest: createContentDigest(existingAssetsWithoutMetadata),
-    },
-  });
-
-  reporter.info(
-    `[site] Create SomeBadImageData with existing asset without metadata`
-  );
-
-  const noAssetInfo = {};
-
-  createNode({
-    id: createNodeId(`SomeBadImageData >>> 2`),
-    name: 'NoAssetInfo',
-    internal: {
-      type: 'SomeBadImageData',
-      contentDigest: createContentDigest(noAssetInfo),
-    },
-  });
-
-  reporter.info(`[site] Create SomeBadImageData without asset info`);
-
-  const nonExistingAsset = {
-    cloudName: 'not-a-good-cloudName',
-    publicId: 'sample',
-  };
-
-  createNode({
-    id: createNodeId(`SomeBadImageData >>> 3`),
-    name: 'BadMetaData',
-    ...nonExistingAsset,
-    internal: {
-      type: 'SomeBadImageData',
-      contentDigest: createContentDigest(nonExistingAsset),
-    },
-  });
-
-  reporter.info(`[site] Create SomeBadImageData with nonexisting asset`);
-
-  const existingVideoWithoutMetadata = {
-    cloudName: 'lilly-labs-consulting',
-    publicId: 'diverse mime types/chop-chop-video.mp4',
-  };
-
-  createNode({
-    id: createNodeId(`SomeBadImageData >>> 4`),
-    name: 'ExistingVideoWithoutMetadata',
-    ...existingVideoWithoutMetadata,
-    internal: {
-      type: 'SomeBadImageData',
-      contentDigest: createContentDigest(existingVideoWithoutMetadata),
-    },
-  });
-
-  reporter.info(
-    `[site] Create SomeBadImageData with existing video asset without metadata`
-  );
-
-  const existingGifWithoutMetadata = {
-    cloudName: 'lilly-labs-consulting',
-    publicId: 'diverse%20mime%20types/giphyCat.gif',
-  };
-
-  createNode({
-    id: createNodeId(`SomeBadImageData >>> 5`),
-    name: 'ExistingGifWithoutMetadata',
-    ...existingGifWithoutMetadata,
-    internal: {
-      type: 'SomeBadImageData',
-      contentDigest: createContentDigest(existingGifWithoutMetadata),
-    },
-  });
-
-  reporter.info(
-    `[site] Create SomeBadImageData with gif asset without metadata`
-  );
-
-  const existingGifWithMetadata = {
-    cloudName: 'lilly-labs-consulting',
-    publicId: 'diverse%20mime%20types/giphyCat.gif',
-    originalWidth: 480,
-    originalHeight: 315,
-    originalFormat: 'gif',
-  };
-
-  createNode({
-    id: createNodeId(`SomeBadImageData >>> 6`),
-    name: 'ExistingGifWithMetadata',
-    ...existingGifWithMetadata,
-    internal: {
-      type: 'SomeBadImageData',
-      contentDigest: createContentDigest(existingGifWithMetadata),
-    },
-  });
-
-  reporter.info(
-    `[site] Create SomeBadImageData with gif asset without metadata`
-  );
-
-  const existingPdfWithoutMetadata = {
-    cloudName: 'lilly-labs-consulting',
-    publicId: 'diverse%20mime%20types/en-US-YearCompass-booklet.pdf',
-  };
-
-  createNode({
-    id: createNodeId(`SomeBadImageData >>> 7`),
-    name: 'ExistingPDFWithoutMetadata',
-    ...existingPdfWithoutMetadata,
-    internal: {
-      type: 'SomeBadImageData',
-      contentDigest: createContentDigest(existingPdfWithoutMetadata),
-    },
-  });
-
-  reporter.info(
-    `[site] Create SomeBadImageData with pdf asset without metadata`
-  );
-
-  const existingPdfWithPDFMetadata = {
-    cloudName: 'lilly-labs-consulting',
-    publicId: 'diverse%20mime%20types/en-US-YearCompass-booklet.pdf',
-    originalWidth: 1650,
-    originalHeight: 1275,
-    originalFormat: 'pdf',
-  };
-
-  createNode({
-    id: createNodeId(`SomeBadImageData >>> 8`),
-    name: 'ExistingPdfWithPDFMetadata',
-    ...existingPdfWithPDFMetadata,
-    internal: {
-      type: 'SomeBadImageData',
-      contentDigest: createContentDigest(existingPdfWithPDFMetadata),
-    },
-  });
-
-  reporter.info(
-    `[site] Create SomeBadImageData with pdf asset with pdf metadata`
-  );
-
-  const existingPdfWithPNGMetadata = {
-    cloudName: 'lilly-labs-consulting',
-    publicId: 'diverse%20mime%20types/en-US-YearCompass-booklet.pdf',
-    originalWidth: 1650,
-    originalHeight: 1275,
-    originalFormat: 'png',
-  };
-
-  createNode({
-    id: createNodeId(`SomeBadImageData >>> 9`),
-    name: 'ExistingPdfWithPNGMetadata',
-    ...existingPdfWithPNGMetadata,
-    internal: {
-      type: 'SomeBadImageData',
-      contentDigest: createContentDigest(existingPdfWithPNGMetadata),
-    },
-  });
-
-  reporter.info(
-    `[site] Create SomeBadImageData with pdf asset with png metadata`
-  );
 
   const blogPostData1 = {
     title: 'Blog Post Example One',
     slug: 'post-1',
-    heroImage: existingAssetsWithoutMetadata,
+    heroImage: sampleAsset,
   };
 
   createNode({
@@ -199,7 +185,7 @@ exports.sourceNodes = (gatsbyUtils) => {
     title: 'Article Example One',
     slug: 'article-1',
     feature: {
-      image: existingAssetsWithoutMetadata,
+      image: sampleAsset,
     },
   };
 

--- a/demo/gatsby-node.js
+++ b/demo/gatsby-node.js
@@ -39,7 +39,8 @@ exports.sourceNodes = (gatsbyUtils) => {
       publicId: 'sample',
       originalWidth: 864,
       originalHeight: 576,
-      originalFormat: 'jpg',
+      // No originalFormat
+      // originalFormat: 'jpg',
     },
     {
       name: 'Video without metadata',

--- a/demo/gatsby-node.js
+++ b/demo/gatsby-node.js
@@ -156,6 +156,30 @@ exports.sourceNodes = (gatsbyUtils) => {
     reporter.info(`[site] Create VariedData: ${asset.name}`);
   });
 
+  const emptyData = [
+    { name: 'Empty data', expected: 'No image', cloudinary: {} },
+    { name: 'Undefined data', expected: 'No image', cloudinary: undefined },
+    { name: 'Null data', expected: 'No image', cloudinary: null },
+    {
+      name: 'Non empty data',
+      expected: 'An image',
+      cloudinary: { cloudName: 'lilly-labs-consulting', publicId: 'sample' },
+    },
+  ];
+
+  emptyData.forEach((asset, key) => {
+    createNode({
+      id: createNodeId(`EmptyData >>> ${key}`),
+      ...asset,
+      internal: {
+        type: 'EmptyData',
+        contentDigest: createContentDigest(asset),
+      },
+    });
+
+    reporter.info(`[site] Create EmptyData: ${key}`);
+  });
+
   const sampleAsset = {
     name: 'Asset with metadata',
     cloudName: 'lilly-labs-consulting',

--- a/demo/gatsby-node.js
+++ b/demo/gatsby-node.js
@@ -30,6 +30,21 @@ exports.sourceNodes = (gatsbyUtils) => {
     },
   });
 
+  const cloudinaryBadMetaData = {
+    cloudName: 'not-a-good-cloudName',
+    publicId: 'sample',
+  };
+
+  createNode({
+    id: createNodeId(`BadMetaData >>> 2`),
+    name: 'BadMetaData',
+    ...cloudinaryBadMetaData,
+    internal: {
+      type: 'SomeBadImageData',
+      contentDigest: createContentDigest(cloudinaryBadMetaData),
+    },
+  });
+
   const blogPostData1 = {
     title: 'Blog Post Example One',
     slug: 'post-1',

--- a/demo/gatsby-node.js
+++ b/demo/gatsby-node.js
@@ -6,49 +6,119 @@ exports.sourceNodes = (gatsbyUtils) => {
     gatsbyUtils;
   const { createNode } = actions;
 
-  const cloudinaryData = {
+  const existingAssetsWithoutMetadata = {
     cloudName: 'lilly-labs-consulting',
     publicId: 'sample',
   };
 
   createNode({
-    id: createNodeId(`GoodData >>> 1`),
+    id: createNodeId(`SomeBadImageData >>> 1`),
     name: 'GoodData',
-    ...cloudinaryData,
+    ...existingAssetsWithoutMetadata,
     internal: {
       type: 'SomeBadImageData',
-      contentDigest: createContentDigest(cloudinaryData),
+      contentDigest: createContentDigest(existingAssetsWithoutMetadata),
     },
   });
+
+  reporter.info(
+    `[site] Create SomeBadImageData with existing asset without metadata`
+  );
+
+  const noAssetInfo = {};
 
   createNode({
-    id: createNodeId(`BadData >>> 2`),
-    name: 'BadData',
+    id: createNodeId(`SomeBadImageData >>> 2`),
+    name: 'NoAssetInfo',
     internal: {
       type: 'SomeBadImageData',
-      contentDigest: createContentDigest({}),
+      contentDigest: createContentDigest(noAssetInfo),
     },
   });
 
-  const cloudinaryBadMetaData = {
+  reporter.info(`[site] Create SomeBadImageData without asset info`);
+
+  const nonExistingAsset = {
     cloudName: 'not-a-good-cloudName',
     publicId: 'sample',
   };
 
   createNode({
-    id: createNodeId(`BadMetaData >>> 2`),
+    id: createNodeId(`SomeBadImageData >>> 3`),
     name: 'BadMetaData',
-    ...cloudinaryBadMetaData,
+    ...nonExistingAsset,
     internal: {
       type: 'SomeBadImageData',
-      contentDigest: createContentDigest(cloudinaryBadMetaData),
+      contentDigest: createContentDigest(nonExistingAsset),
     },
   });
+
+  reporter.info(`[site] Create SomeBadImageData with nonexisting asset`);
+
+  const existingVideoWithoutMetadata = {
+    cloudName: 'lilly-labs-consulting',
+    publicId: 'diverse mime types/chop-chop-video.mp4',
+  };
+
+  createNode({
+    id: createNodeId(`SomeBadImageData >>> 4`),
+    name: 'ExistingVideoWithoutMetadata',
+    ...existingVideoWithoutMetadata,
+    internal: {
+      type: 'SomeBadImageData',
+      contentDigest: createContentDigest(existingVideoWithoutMetadata),
+    },
+  });
+
+  reporter.info(
+    `[site] Create SomeBadImageData with existing video asset without metadata`
+  );
+
+  const existingGifWithoutMetadata = {
+    cloudName: 'lilly-labs-consulting',
+    publicId: 'diverse%20mime%20types/giphyCat.gif',
+  };
+
+  createNode({
+    id: createNodeId(`SomeBadImageData >>> 5`),
+    name: 'ExistingGifWithoutMetadata',
+    ...existingGifWithoutMetadata,
+    internal: {
+      type: 'SomeBadImageData',
+      contentDigest: createContentDigest(existingGifWithoutMetadata),
+    },
+  });
+
+  reporter.info(
+    `[site] Create SomeBadImageData with gif asset without metadata`
+  );
+
+  const existingGifWithMetadata = {
+    cloudName: 'lilly-labs-consulting',
+    publicId: 'diverse%20mime%20types/giphyCat.gif',
+    originalWidth: 480,
+    originalHeight: 315,
+    originalFormat: 'gif',
+  };
+
+  createNode({
+    id: createNodeId(`SomeBadImageData >>> 6`),
+    name: 'ExistingGifWithMetadata',
+    ...existingGifWithMetadata,
+    internal: {
+      type: 'SomeBadImageData',
+      contentDigest: createContentDigest(existingGifWithMetadata),
+    },
+  });
+
+  reporter.info(
+    `[site] Create SomeBadImageData with gif asset without metadata`
+  );
 
   const blogPostData1 = {
     title: 'Blog Post Example One',
     slug: 'post-1',
-    heroImage: cloudinaryData,
+    heroImage: existingAssetsWithoutMetadata,
   };
 
   createNode({
@@ -66,7 +136,7 @@ exports.sourceNodes = (gatsbyUtils) => {
     title: 'Article Example One',
     slug: 'article-1',
     feature: {
-      image: cloudinaryData,
+      image: existingAssetsWithoutMetadata,
     },
   };
 

--- a/demo/src/pages/manual-tests/no-data.js
+++ b/demo/src/pages/manual-tests/no-data.js
@@ -2,21 +2,23 @@ import React from 'react';
 import { graphql, useStaticQuery } from 'gatsby';
 import { GatsbyImage, getImage } from 'gatsby-plugin-image';
 
-const VariedDataPage = () => {
+const EmptyDataPage = () => {
   const data = useStaticQuery(graphql`
     query {
-      allVariedData {
+      allEmptyData {
         nodes {
           name
           expected
-          gatsbyImageData(height: 200, backgroundColor: "#BADA55")
+          cloudinary {
+            gatsbyImageData(width: 200, backgroundColor: "#BADA55")
+          }
         }
       }
     }
   `);
 
-  return data.allVariedData.nodes.map((node, index) => {
-    const gatsbyImage = getImage(node);
+  return data.allEmptyData.nodes.map((node, index) => {
+    const gatsbyImage = getImage(node.cloudinary);
 
     return (
       <>
@@ -34,4 +36,4 @@ const VariedDataPage = () => {
   });
 };
 
-export default VariedDataPage;
+export default EmptyDataPage;

--- a/demo/src/pages/manual-tests/varied-data.js
+++ b/demo/src/pages/manual-tests/varied-data.js
@@ -5,21 +5,25 @@ import { GatsbyImage, getImage } from 'gatsby-plugin-image';
 const ProblemExample = () => {
   const data = useStaticQuery(graphql`
     query {
-      allSomeBadImageData {
+      allVariedData {
         nodes {
           name
+          expected
           gatsbyImageData(height: 200, backgroundColor: "#BADA55")
         }
       }
     }
   `);
 
-  return data.allSomeBadImageData.nodes.map((node, index) => {
+  return data.allVariedData.nodes.map((node, index) => {
     const gatsbyImage = getImage(node);
 
     return (
       <>
         <h2>{node.name}</h2>
+        <div>
+          <strong>Expected:</strong> {node.expected}
+        </div>
         {gatsbyImage ? (
           <GatsbyImage key={index} image={gatsbyImage} alt={node.name} />
         ) : (

--- a/demo/src/pages/somebaddata.js
+++ b/demo/src/pages/somebaddata.js
@@ -8,7 +8,7 @@ const ProblemExample = () => {
       allSomeBadImageData {
         nodes {
           name
-          gatsbyImageData(height: 200)
+          gatsbyImageData(height: 200, backgroundColor: "#BADA55")
         }
       }
     }
@@ -17,11 +17,16 @@ const ProblemExample = () => {
   return data.allSomeBadImageData.nodes.map((node, index) => {
     const gatsbyImage = getImage(node);
 
-    if (gatsbyImage) {
-      return <GatsbyImage key={index} image={gatsbyImage} alt={node.name} />;
-    } else {
-      return <div>No image for node with name: {node.name}</div>;
-    }
+    return (
+      <>
+        <h2>{node.name}</h2>
+        {gatsbyImage ? (
+          <GatsbyImage key={index} image={gatsbyImage} alt={node.name} />
+        ) : (
+          <div>No image for node with name: {node.name}</div>
+        )}
+      </>
+    );
   });
 };
 

--- a/plugin/gatsby-plugin-image/asset-data.test.js
+++ b/plugin/gatsby-plugin-image/asset-data.test.js
@@ -1,6 +1,8 @@
 jest.mock('axios');
+jest.mock('probe-image-size');
 
 const axios = require('axios');
+const probe = require('probe-image-size');
 const {
   getAssetMetadata,
   getUrlAsBase64Image,
@@ -18,7 +20,12 @@ const args = {
 
 describe('getAssetMetaData', () => {
   beforeEach(() => {
-    axios.get.mockResolvedValue({ data: { output: 'metadata' } });
+    probe.mockResolvedValue({
+      width: 400,
+      height: 300,
+      type: 'jpg',
+      extra: 'extra',
+    });
   });
 
   afterEach(() => {
@@ -27,15 +34,14 @@ describe('getAssetMetaData', () => {
 
   it('fetches the correct metadata url', async () => {
     await getAssetMetadata({ source, args });
-    expect(axios.get).toHaveBeenCalledWith(
-      `http://res.cloudinary.com/cloud-name/image/upload/e_grayscale/fl_getinfo/public-id`,
-      undefined
+    expect(probe).toHaveBeenCalledWith(
+      `http://res.cloudinary.com/cloud-name/image/upload/f_auto,e_grayscale/public-id`
     );
   });
 
   it('returns the metadata', async () => {
     const metadata = await getAssetMetadata({ source, args });
-    expect(metadata).toBe('metadata');
+    expect(metadata).toStrictEqual({ width: 400, height: 300, format: 'jpg' });
   });
 
   it('to cache responses', async () => {
@@ -43,7 +49,7 @@ describe('getAssetMetaData', () => {
     await getAssetMetadata({ source, args: {} });
     await getAssetMetadata({ source, args: { chained: ['t_lwj'] } });
     await getAssetMetadata({ source, args: { chained: ['t_lwj'] } });
-    expect(axios.get).toHaveBeenCalledTimes(2);
+    expect(probe).toHaveBeenCalledTimes(2);
   });
 });
 

--- a/plugin/gatsby-plugin-image/generate-asset-url.js
+++ b/plugin/gatsby-plugin-image/generate-asset-url.js
@@ -3,7 +3,7 @@ const cloudinary = require('cloudinary').v2;
 const generateTransformations = ({ width, height, format, options = {} }) => {
   return [
     {
-      fetch_format: format,
+      fetch_format: format || 'auto',
       width: width,
       height: height,
       raw_transformation: (options.transformations || []).join(','),

--- a/plugin/gatsby-plugin-image/resolve-asset.js
+++ b/plugin/gatsby-plugin-image/resolve-asset.js
@@ -73,14 +73,24 @@ exports.createResolveCloudinaryAssetData =
         metadata = await getAssetMetadata({ source, args });
         reporter.verbose(
           `[gatsby-transformer-cloudinary] Missing metadata fields on ${transformType}: cloudName=${source.cloudName}, publicId=${source.publicId}
-          >>> To save on network requests add originalWidth, originalHeight and originalFormat to ${transformType}`
+              >>> To save on network requests add originalWidth, originalHeight and originalFormat to ${transformType}`
         );
       } catch (error) {
         reporter.warn(
-          `[gatsby-transformer-cloudinary] Could not get metadata for ${transformType}: cloudName=${source.cloudName}, publicId=${source.publicId}`
+          `[gatsby-transformer-cloudinary] Could not get metadata for ${transformType}: cloudName=${source.cloudName}, publicId=${source.publicId}
+              >>> gatsbyImageData will resolve to null`
         );
         return null;
       }
+    }
+
+    if (!hasRequiredMetaData(metadata)) {
+      reporter.warn(
+        `[gatsby-transformer-cloudinary] Fetched metadata for ${transformType}: cloudName=${source.cloudName}, publicId=${source.publicId}
+            >>> does not comply: width=${metadata.width}, height=${metadata.height}, format=${metadata.format}
+            >>> gatsbyImageData will resolve to null`
+      );
+      return null;
     }
 
     const assetDataArgs = {

--- a/plugin/gatsby-plugin-image/resolve-asset.js
+++ b/plugin/gatsby-plugin-image/resolve-asset.js
@@ -97,14 +97,30 @@ exports.createResolveCloudinaryAssetData =
   (gatsbyUtils) => async (source, args, _context, info) => {
     const { reporter } = gatsbyUtils;
     const transformType = info.parentType || 'UnknownTransformType';
-    const hasRequiredData = (source) => {
-      return source?.cloudName && source?.publicId;
-    };
 
-    if (!hasRequiredData(source)) {
-      reporter.warn(
-        `[gatsby-transformer-cloudinary] Missing required fields on ${transformType}: cloudName=${source.cloudName}, publicId=${source.publicId}`
-      );
+    const schema = Joi.object({
+      cloudName: Joi.string().required(),
+      publicId: Joi.string().required(),
+    }).required();
+
+    const { error } = schema.validate(source, {
+      allowUnknown: true,
+      abortEarly: false,
+    });
+
+    if (error) {
+      if (error.details.length < 2) {
+        reporter.warn(
+          `[gatsby-transformer-cloudinary] Missing required field on ${transformType}: cloudName=${source.cloudName}, publicId=${source.publicId}`
+        );
+        reporter.warn(`>>> gatsbyImageData will resolve to null`);
+      } else {
+        reporter.verbose(
+          `[gatsby-transformer-cloudinary] Missing cloudName and publicId on ${transformType}`
+        );
+        reporter.verbose(`>>> gatsbyImageData will resolve to null`);
+      }
+
       return null;
     }
 

--- a/plugin/gatsby-plugin-image/resolve-asset.js
+++ b/plugin/gatsby-plugin-image/resolve-asset.js
@@ -63,10 +63,7 @@ const generateMetadata = async (source, args, transformType, reporter) => {
   try {
     // Lacking metadata, so lets request it from Cloudinary
     reporter.verbose(
-      `[gatsby-transformer-cloudinary] Missing metadata fields on ${transformType}: cloudName=${source.cloudName}, publicId=${source.publicId}`
-    );
-    reporter.verbose(
-      `  >>>  To save on network requests add originalWidth, originalHeight and originalFormat to ${transformType}`
+      `[gatsby-transformer-cloudinary] Missing metadata fields on ${transformType}: cloudName=${source.cloudName}, publicId=${source.publicId} >>> To save on network requests add originalWidth, originalHeight and originalFormat to ${transformType}`
     );
 
     const fetchedMetadata = await getAssetMetadata({ source, args });
@@ -77,16 +74,14 @@ const generateMetadata = async (source, args, transformType, reporter) => {
       return value;
     } else {
       reporter.verbose(
-        `[gatsby-transformer-cloudinary] Invalid fetched metadata for ${transformType}: cloudName=${source.cloudName}, publicId=${source.publicId}`
+        `[gatsby-transformer-cloudinary] Invalid fetched metadata for ${transformType}: cloudName=${source.cloudName}, publicId=${source.publicId} >>> ${error.message}`
       );
-      reporter.verbose(`[gatsby-transformer-cloudinary] >>> ${error.message}`);
       return null;
     }
   } catch (error) {
     reporter.verbose(
-      `[gatsby-transformer-cloudinary] Could not fetch metadata for ${transformType}: cloudName=${source.cloudName}, publicId=${source.publicId}`
+      `[gatsby-transformer-cloudinary] Could not fetch metadata for ${transformType}: cloudName=${source.cloudName}, publicId=${source.publicId} >>> ${error.message}`
     );
-    reporter.verbose(`[gatsby-transformer-cloudinary] >>> ${error.message}`);
     return null;
   }
 };
@@ -112,17 +107,11 @@ exports.createResolveCloudinaryAssetData =
     if (error) {
       if (error.details.length < 2) {
         reporter.warn(
-          `[gatsby-transformer-cloudinary] Missing required field on ${transformType}: cloudName=${source.cloudName}, publicId=${source.publicId}`
-        );
-        reporter.warn(
-          `[gatsby-transformer-cloudinary] >>> gatsbyImageData will resolve to null`
+          `[gatsby-transformer-cloudinary] Missing required field on ${transformType}: cloudName=${source.cloudName}, publicId=${source.publicId} >>> gatsbyImageData will resolve to null`
         );
       } else {
         reporter.verbose(
-          `[gatsby-transformer-cloudinary] Missing cloudName and publicId on ${transformType}`
-        );
-        reporter.verbose(
-          `[gatsby-transformer-cloudinary] >>> gatsbyImageData will resolve to null`
+          `[gatsby-transformer-cloudinary] Missing cloudName and publicId on ${transformType} >>> gatsbyImageData will resolve to null`
         );
       }
 
@@ -138,10 +127,7 @@ exports.createResolveCloudinaryAssetData =
 
     if (!metadata) {
       reporter.warn(
-        `[gatsby-transformer-cloudinary] No metadata for ${transformType}: cloudName=${source.cloudName}, publicId=${source.publicId}`
-      );
-      reporter.warn(
-        `[gatsby-transformer-cloudinary] >>> gatsbyImageData will resolve to null`
+        `[gatsby-transformer-cloudinary] No metadata for ${transformType}: cloudName=${source.cloudName}, publicId=${source.publicId} >>> gatsbyImageData will resolve to null`
       );
       return null;
     }

--- a/plugin/gatsby-plugin-image/resolve-asset.js
+++ b/plugin/gatsby-plugin-image/resolve-asset.js
@@ -108,9 +108,9 @@ exports.createResolveCloudinaryAssetData =
     });
 
     if (error) {
-      if (error.details.length < 2) {
+      if (error.details.length < 2 && error.details[0].path.length > 0) {
         reporter.warn(
-          `[gatsby-transformer-cloudinary] Missing required field on ${transformType}: cloudName=${source.cloudName}, publicId=${source.publicId} >>> gatsbyImageData will resolve to null`
+          `[gatsby-transformer-cloudinary] Missing required field on ${transformType}: cloudName=${source?.cloudName}, publicId=${source?.publicId} >>> gatsbyImageData will resolve to null`
         );
       } else {
         reporter.verbose(

--- a/plugin/gatsby-plugin-image/resolve-asset.js
+++ b/plugin/gatsby-plugin-image/resolve-asset.js
@@ -70,9 +70,7 @@ const generateMetadata = async (source, args, transformType, reporter) => {
     );
 
     const fetchedMetadata = await getAssetMetadata({ source, args });
-    const { value, error } = schema.validate(fetchedMetadata, {
-      stripUnknown: true,
-    });
+    const { value, error } = schema.validate(fetchedMetadata);
 
     if (!error) {
       // Value is the validate fetchedMetadata stripped for unknowns

--- a/plugin/gatsby-plugin-image/resolve-asset.js
+++ b/plugin/gatsby-plugin-image/resolve-asset.js
@@ -43,7 +43,7 @@ const generateMetadata = async (source, args, transformType, reporter) => {
   const schema = Joi.object({
     width: Joi.number().positive().required(),
     height: Joi.number().positive().required(),
-    format: Joi.string().required(),
+    format: Joi.string().default('auto'),
   }).required();
 
   const originalMetadata = {

--- a/plugin/gatsby-plugin-image/resolve-asset.js
+++ b/plugin/gatsby-plugin-image/resolve-asset.js
@@ -55,13 +55,13 @@ const generateMetadata = async (source, args, transformType, reporter) => {
   const { value, error } = schema.validate(originalMetadata);
 
   if (!error) {
-    // Original metadata is good,
+    // Original metadata is valid,
     // use validated value
     return value;
   }
 
   try {
-    // Lacking metadata, so lets request it from Cloudinary
+    // Lacking metadata, so let's fetch it
     reporter.verbose(
       `[gatsby-transformer-cloudinary] Missing metadata fields on ${transformType}: cloudName=${source.cloudName}, publicId=${source.publicId} >>> To save on network requests add originalWidth, originalHeight and originalFormat to ${transformType}`
     );
@@ -70,15 +70,18 @@ const generateMetadata = async (source, args, transformType, reporter) => {
     const { value, error } = schema.validate(fetchedMetadata);
 
     if (!error) {
-      // Value is the validate fetchedMetadata stripped for unknowns
+      // Fetched metadata is valid,
+      // use validated value
       return value;
     } else {
+      // Fetched metadata is not valid
       reporter.verbose(
         `[gatsby-transformer-cloudinary] Invalid fetched metadata for ${transformType}: cloudName=${source.cloudName}, publicId=${source.publicId} >>> ${error.message}`
       );
       return null;
     }
   } catch (error) {
+    // Error fetching
     reporter.verbose(
       `[gatsby-transformer-cloudinary] Could not fetch metadata for ${transformType}: cloudName=${source.cloudName}, publicId=${source.publicId} >>> ${error.message}`
     );

--- a/plugin/gatsby-plugin-image/resolve-asset.js
+++ b/plugin/gatsby-plugin-image/resolve-asset.js
@@ -66,7 +66,7 @@ const generateMetadata = async (source, args, transformType, reporter) => {
       `[gatsby-transformer-cloudinary] Missing metadata fields on ${transformType}: cloudName=${source.cloudName}, publicId=${source.publicId}`
     );
     reporter.verbose(
-      `>>> To save on network requests add originalWidth, originalHeight and originalFormat to ${transformType}`
+      `  >>>  To save on network requests add originalWidth, originalHeight and originalFormat to ${transformType}`
     );
 
     const fetchedMetadata = await getAssetMetadata({ source, args });
@@ -81,14 +81,14 @@ const generateMetadata = async (source, args, transformType, reporter) => {
       reporter.verbose(
         `[gatsby-transformer-cloudinary] Invalid fetched metadata for ${transformType}: cloudName=${source.cloudName}, publicId=${source.publicId}`
       );
-      reporter.verbose(`>>> ${error.message}`);
+      reporter.verbose(`[gatsby-transformer-cloudinary] >>> ${error.message}`);
       return null;
     }
   } catch (error) {
     reporter.verbose(
       `[gatsby-transformer-cloudinary] Could not fetch metadata for ${transformType}: cloudName=${source.cloudName}, publicId=${source.publicId}`
     );
-    reporter.verbose(`>>> ${error.message}`);
+    reporter.verbose(`[gatsby-transformer-cloudinary] >>> ${error.message}`);
     return null;
   }
 };
@@ -116,12 +116,16 @@ exports.createResolveCloudinaryAssetData =
         reporter.warn(
           `[gatsby-transformer-cloudinary] Missing required field on ${transformType}: cloudName=${source.cloudName}, publicId=${source.publicId}`
         );
-        reporter.warn(`>>> gatsbyImageData will resolve to null`);
+        reporter.warn(
+          `[gatsby-transformer-cloudinary] >>> gatsbyImageData will resolve to null`
+        );
       } else {
         reporter.verbose(
           `[gatsby-transformer-cloudinary] Missing cloudName and publicId on ${transformType}`
         );
-        reporter.verbose(`>>> gatsbyImageData will resolve to null`);
+        reporter.verbose(
+          `[gatsby-transformer-cloudinary] >>> gatsbyImageData will resolve to null`
+        );
       }
 
       return null;
@@ -138,7 +142,9 @@ exports.createResolveCloudinaryAssetData =
       reporter.warn(
         `[gatsby-transformer-cloudinary] No metadata for ${transformType}: cloudName=${source.cloudName}, publicId=${source.publicId}`
       );
-      reporter.warn(`>>> gatsbyImageData will resolve to null`);
+      reporter.warn(
+        `[gatsby-transformer-cloudinary] >>> gatsbyImageData will resolve to null`
+      );
       return null;
     }
 

--- a/plugin/gatsby-plugin-image/resolve-asset.js
+++ b/plugin/gatsby-plugin-image/resolve-asset.js
@@ -52,11 +52,12 @@ const generateMetadata = async (source, args, transformType, reporter) => {
     format: source.originalFormat,
   };
 
-  const { error } = schema.validate(originalMetadata);
+  const { value, error } = schema.validate(originalMetadata);
 
   if (!error) {
-    // Original metadata is good, use it
-    return originalMetadata;
+    // Original metadata is good,
+    // use validated value
+    return value;
   }
 
   try {
@@ -69,11 +70,13 @@ const generateMetadata = async (source, args, transformType, reporter) => {
     );
 
     const fetchedMetadata = await getAssetMetadata({ source, args });
-    const { error } = schema.validate(fetchedMetadata);
+    const { value, error } = schema.validate(fetchedMetadata, {
+      stripUnknown: true,
+    });
 
     if (!error) {
-      // Fetched data is good, use it
-      return fetchedMetadata;
+      // Value is the validate fetchedMetadata stripped for unknowns
+      return value;
     } else {
       reporter.verbose(
         `[gatsby-transformer-cloudinary] Invalid fetched metadata for ${transformType}: cloudName=${source.cloudName}, publicId=${source.publicId}`

--- a/plugin/gatsby-plugin-image/resolve-asset.test.js
+++ b/plugin/gatsby-plugin-image/resolve-asset.test.js
@@ -81,7 +81,6 @@ describe('resolveCloudinaryAssetData', () => {
       width: 100,
       height: 200,
       format: 'gif',
-      bytes: 6779,
     });
     getUrlAsBase64Image.mockResolvedValue('base64DataUrl');
     getAssetAsTracedSvg.mockResolvedValue('svgDataUrl');
@@ -110,8 +109,8 @@ describe('resolveCloudinaryAssetData', () => {
       pluginName: 'gatsby-transformer-cloudinary',
       sourceMetadata: {
         format: 'jpg',
-        height: '300',
-        width: '600',
+        height: 300,
+        width: 600,
       },
       transformations: ['e_grayscale'],
     });
@@ -123,8 +122,9 @@ describe('resolveCloudinaryAssetData', () => {
     await resolveCloudinaryAssetData(sourceWithoutMeta, args, context, info);
     // getAssetMetadata should only be called for sourceWithoutMeta
     expect(getAssetMetadata).toBeCalledTimes(1);
-    expect(gatsbyUtilsMocks.reporter.verbose).toBeCalledTimes(2);
+    expect(gatsbyUtilsMocks.reporter.verbose).toBeCalledTimes(1);
     // gatsby-plugin-image -> generateImageData should be called for both
+    expect(generateImageData).toBeCalledTimes(2);
     expect(generateImageData).toHaveBeenNthCalledWith(2, {
       filename: 'cloud-name>>>public-id',
       generateImageSource: _generateCloudinaryAssetSource,
@@ -151,8 +151,8 @@ describe('resolveCloudinaryAssetData', () => {
       pluginName: 'gatsby-transformer-cloudinary',
       sourceMetadata: {
         format: 'jpg',
-        height: '300',
-        width: '600',
+        height: 300,
+        width: 600,
       },
       placeholderURL: 'base64DataUrl',
       placeholder: 'blurred',
@@ -171,8 +171,8 @@ describe('resolveCloudinaryAssetData', () => {
       pluginName: 'gatsby-transformer-cloudinary',
       sourceMetadata: {
         format: 'jpg',
-        height: '300',
-        width: '600',
+        height: 300,
+        width: 600,
       },
       placeholderURL: 'svgDataUrl',
       placeholder: 'tracedSVG',
@@ -190,7 +190,7 @@ describe('resolveCloudinaryAssetData', () => {
         info
       );
       expect(generateImageData).toBeCalledTimes(0);
-      expect(gatsbyUtilsMocks.reporter.verbose).toBeCalledTimes(2);
+      expect(gatsbyUtilsMocks.reporter.verbose).toBeCalledTimes(1);
       expect(result).toBe(null);
     });
   });
@@ -208,7 +208,7 @@ describe('resolveCloudinaryAssetData', () => {
         info
       );
       expect(generateImageData).toBeCalledTimes(0);
-      expect(gatsbyUtilsMocks.reporter.warn).toBeCalledTimes(2);
+      expect(gatsbyUtilsMocks.reporter.warn).toBeCalledTimes(1);
       expect(result).toBe(null);
     });
   });
@@ -236,7 +236,7 @@ describe('resolveCloudinaryAssetData', () => {
       );
       expect(getAssetMetadata).toBeCalledTimes(1);
       expect(generateImageData).toBeCalledTimes(0);
-      expect(gatsbyUtilsMocks.reporter.warn).toBeCalledTimes(2);
+      expect(gatsbyUtilsMocks.reporter.warn).toBeCalledTimes(1);
       expect(result).toBe(null);
     });
   });
@@ -260,7 +260,7 @@ describe('resolveCloudinaryAssetData', () => {
       );
       expect(getAssetMetadata).toBeCalledTimes(1);
       expect(generateImageData).toBeCalledTimes(0);
-      expect(gatsbyUtilsMocks.reporter.warn).toBeCalledTimes(2);
+      expect(gatsbyUtilsMocks.reporter.warn).toBeCalledTimes(1);
       expect(result).toBe(null);
     });
   });
@@ -293,7 +293,7 @@ describe('resolveCloudinaryAssetData', () => {
       );
       expect(getAssetMetadata).toBeCalledTimes(1);
       expect(generateImageData).toBeCalledTimes(0);
-      expect(gatsbyUtilsMocks.reporter.warn).toBeCalledTimes(2);
+      expect(gatsbyUtilsMocks.reporter.warn).toBeCalledTimes(1);
       expect(result).toBe(null);
     });
 
@@ -310,8 +310,8 @@ describe('resolveCloudinaryAssetData', () => {
         pluginName: 'gatsby-transformer-cloudinary',
         sourceMetadata: {
           format: 'jpg',
-          height: '300',
-          width: '600',
+          height: 300,
+          width: 600,
         },
         //  placeholderURL: 'base64DataUrl',
         placeholder: 'blurred',
@@ -330,8 +330,8 @@ describe('resolveCloudinaryAssetData', () => {
         pluginName: 'gatsby-transformer-cloudinary',
         sourceMetadata: {
           format: 'jpg',
-          height: '300',
-          width: '600',
+          height: 300,
+          width: 600,
         },
         // placeholderURL: 'svgDataUrl',
         placeholder: 'tracedSVG',

--- a/plugin/gatsby-plugin-image/resolve-asset.test.js
+++ b/plugin/gatsby-plugin-image/resolve-asset.test.js
@@ -202,8 +202,8 @@ describe('resolveCloudinaryAssetData', () => {
     });
   });
 
-  describe('when missing required data', () => {
-    it('calls reporter.verbose and returns null', async () => {
+  describe('when unconforming source', () => {
+    it('calls reporter.verbose and returns null for empty source', async () => {
       const source = {};
       const args = {};
       const result = await resolveCloudinaryAssetData(
@@ -216,12 +216,56 @@ describe('resolveCloudinaryAssetData', () => {
       expect(gatsbyUtilsMocks.reporter.verbose).toBeCalledTimes(1);
       expect(result).toBe(null);
     });
-  });
 
-  describe('when missing some required data', () => {
-    it('calls reporter.warn and returns null', async () => {
+    it('calls reporter.verbose and returns null for weird source', async () => {
+      const source = {
+        one: 'thing',
+        another: 'thang',
+      };
+      const args = {};
+      const result = await resolveCloudinaryAssetData(
+        source,
+        args,
+        context,
+        info
+      );
+      expect(generateImageData).toBeCalledTimes(0);
+      expect(gatsbyUtilsMocks.reporter.verbose).toBeCalledTimes(1);
+      expect(result).toBe(null);
+    });
+
+    it('calls reporter.verbose and returns null for null source', async () => {
+      const source = null;
+      const args = {};
+      const result = await resolveCloudinaryAssetData(
+        source,
+        args,
+        context,
+        info
+      );
+      expect(generateImageData).toBeCalledTimes(0);
+      expect(gatsbyUtilsMocks.reporter.verbose).toBeCalledTimes(1);
+      expect(result).toBe(null);
+    });
+
+    it('calls reporter.verbose and returns null for undefined source', async () => {
+      const source = undefined;
+      const args = {};
+      const result = await resolveCloudinaryAssetData(
+        source,
+        args,
+        context,
+        info
+      );
+      expect(generateImageData).toBeCalledTimes(0);
+      expect(gatsbyUtilsMocks.reporter.verbose).toBeCalledTimes(1);
+      expect(result).toBe(null);
+    });
+
+    it('calls reporter.warn and returns null for missing data', async () => {
       const source = {
         publicId: 'publicId',
+        one: 'thing',
       };
       const args = {};
       const result = await resolveCloudinaryAssetData(

--- a/plugin/gatsby-plugin-image/resolve-asset.test.js
+++ b/plugin/gatsby-plugin-image/resolve-asset.test.js
@@ -5,6 +5,7 @@ const gatsbyUtilsMocks = {
   reporter: {
     panic: jest.fn(),
     error: jest.fn(),
+    warn: jest.fn(),
     info: jest.fn(),
     verbose: jest.fn(),
   },
@@ -178,7 +179,7 @@ describe('resolveCloudinaryAssetData', () => {
   });
 
   describe('when missing required data', () => {
-    it('calls reporter.error and returns null', async () => {
+    it('calls reporter.warn and returns null', async () => {
       const source = {};
       const args = {};
       const result = await resolveCloudinaryAssetData(
@@ -188,7 +189,7 @@ describe('resolveCloudinaryAssetData', () => {
         info
       );
       expect(generateImageData).toBeCalledTimes(0);
-      expect(gatsbyUtilsMocks.reporter.error).toBeCalledTimes(1);
+      expect(gatsbyUtilsMocks.reporter.warn).toBeCalledTimes(1);
       expect(result).toBe(null);
     });
   });
@@ -221,7 +222,7 @@ describe('resolveCloudinaryAssetData', () => {
       );
       expect(getAssetMetadata).toBeCalledTimes(1);
       expect(generateImageData).toBeCalledTimes(0);
-      expect(gatsbyUtilsMocks.reporter.error).toBeCalledTimes(1);
+      expect(gatsbyUtilsMocks.reporter.warn).toBeCalledTimes(1);
       expect(result).toBe(null);
     });
 

--- a/plugin/gatsby-plugin-image/resolve-asset.test.js
+++ b/plugin/gatsby-plugin-image/resolve-asset.test.js
@@ -194,6 +194,33 @@ describe('resolveCloudinaryAssetData', () => {
     });
   });
 
+  describe('when missing metadata even after fetching data', () => {
+    beforeEach(() => {
+      getAssetMetadata.mockResolvedValue({
+        width: 100,
+        //  height: 200,
+        //  format: 'gif',
+      });
+    });
+
+    afterEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('calls reporter.warn and returns null', async () => {
+      const args = {};
+      const result = await resolveCloudinaryAssetData(
+        sourceWithoutMeta,
+        args,
+        context,
+        info
+      );
+      expect(generateImageData).toBeCalledTimes(0);
+      expect(gatsbyUtilsMocks.reporter.warn).toBeCalledTimes(1);
+      expect(result).toBe(null);
+    });
+  });
+
   describe('when error fetching asset data', () => {
     beforeEach(() => {
       getAssetMetadata.mockImplementation(() => {

--- a/plugin/gatsby-plugin-image/resolve-asset.test.js
+++ b/plugin/gatsby-plugin-image/resolve-asset.test.js
@@ -68,6 +68,13 @@ describe('resolveCloudinaryAssetData', () => {
     originalFormat: 'jpg',
   };
 
+  const sourceWithoutFormat = {
+    publicId: 'public-id',
+    cloudName: 'cloud-name',
+    originalWidth: '600',
+    originalHeight: '300',
+  };
+
   const sourceWithoutMeta = {
     publicId: 'public-id',
     cloudName: 'cloud-name',
@@ -100,7 +107,9 @@ describe('resolveCloudinaryAssetData', () => {
   it('calls gatsby-plugin-image -> generateImageData with correct data', async () => {
     const args = { transformations: ['e_grayscale'] };
     await resolveCloudinaryAssetData(sourceWithMetadata, args, context, info);
-    expect(generateImageData).toBeCalledWith({
+    await resolveCloudinaryAssetData(sourceWithoutFormat, args, context, info);
+    expect(getAssetMetadata).toBeCalledTimes(0);
+    expect(generateImageData).toHaveBeenNthCalledWith(1, {
       filename: 'cloud-name>>>public-id',
       generateImageSource: _generateCloudinaryAssetSource,
       options: {
@@ -109,6 +118,20 @@ describe('resolveCloudinaryAssetData', () => {
       pluginName: 'gatsby-transformer-cloudinary',
       sourceMetadata: {
         format: 'jpg',
+        height: 300,
+        width: 600,
+      },
+      transformations: ['e_grayscale'],
+    });
+    expect(generateImageData).toHaveBeenNthCalledWith(2, {
+      filename: 'cloud-name>>>public-id',
+      generateImageSource: _generateCloudinaryAssetSource,
+      options: {
+        transformations: ['e_grayscale'],
+      },
+      pluginName: 'gatsby-transformer-cloudinary',
+      sourceMetadata: {
+        format: 'auto',
         height: 300,
         width: 600,
       },

--- a/plugin/gatsby-plugin-image/resolve-asset.test.js
+++ b/plugin/gatsby-plugin-image/resolve-asset.test.js
@@ -194,7 +194,7 @@ describe('resolveCloudinaryAssetData', () => {
     });
   });
 
-  describe('when missing metadata even after fetching data', () => {
+  describe('when fetched asset data is invalid', () => {
     beforeEach(() => {
       getAssetMetadata.mockResolvedValue({
         width: 100,
@@ -215,6 +215,31 @@ describe('resolveCloudinaryAssetData', () => {
         context,
         info
       );
+      expect(getAssetMetadata).toBeCalledTimes(1);
+      expect(generateImageData).toBeCalledTimes(0);
+      expect(gatsbyUtilsMocks.reporter.warn).toBeCalledTimes(1);
+      expect(result).toBe(null);
+    });
+  });
+
+  describe('when fetched asset data is undefined', () => {
+    beforeEach(() => {
+      getAssetMetadata.mockResolvedValue(undefined);
+    });
+
+    afterEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('calls reporter.warn and returns null', async () => {
+      const args = {};
+      const result = await resolveCloudinaryAssetData(
+        sourceWithoutMeta,
+        args,
+        context,
+        info
+      );
+      expect(getAssetMetadata).toBeCalledTimes(1);
       expect(generateImageData).toBeCalledTimes(0);
       expect(gatsbyUtilsMocks.reporter.warn).toBeCalledTimes(1);
       expect(result).toBe(null);
@@ -239,7 +264,7 @@ describe('resolveCloudinaryAssetData', () => {
       jest.clearAllMocks();
     });
 
-    it('calls reporter.error on fetching metadata error and returns null', async () => {
+    it('calls reporter.error on metadata error and returns null', async () => {
       const args = {};
       const result = await resolveCloudinaryAssetData(
         sourceWithoutMeta,
@@ -253,7 +278,7 @@ describe('resolveCloudinaryAssetData', () => {
       expect(result).toBe(null);
     });
 
-    it('calls reporter.error on fetching blurred placeholder error', async () => {
+    it('calls reporter.error on blurred placeholder error', async () => {
       const args = { placeholder: 'blurred' };
       await resolveCloudinaryAssetData(sourceWithMetadata, args, context, info);
       expect(getLowResolutionImageURL).toBeCalledTimes(1);
@@ -274,7 +299,7 @@ describe('resolveCloudinaryAssetData', () => {
       });
     });
 
-    it('calls reporter.error on fetching tracedSVG placeholder error', async () => {
+    it('calls reporter.error on tracedSVG placeholder error', async () => {
       const args = { placeholder: 'tracedSVG' };
       await resolveCloudinaryAssetData(sourceWithMetadata, args, context, info);
       expect(getAssetAsTracedSvg).toBeCalledTimes(1);

--- a/plugin/gatsby-plugin-image/resolve-asset.test.js
+++ b/plugin/gatsby-plugin-image/resolve-asset.test.js
@@ -81,6 +81,7 @@ describe('resolveCloudinaryAssetData', () => {
       width: 100,
       height: 200,
       format: 'gif',
+      bytes: 6779,
     });
     getUrlAsBase64Image.mockResolvedValue('base64DataUrl');
     getAssetAsTracedSvg.mockResolvedValue('svgDataUrl');

--- a/plugin/gatsby-plugin-image/resolve-asset.test.js
+++ b/plugin/gatsby-plugin-image/resolve-asset.test.js
@@ -122,7 +122,7 @@ describe('resolveCloudinaryAssetData', () => {
     await resolveCloudinaryAssetData(sourceWithoutMeta, args, context, info);
     // getAssetMetadata should only be called for sourceWithoutMeta
     expect(getAssetMetadata).toBeCalledTimes(1);
-    expect(gatsbyUtilsMocks.reporter.verbose).toBeCalledTimes(1);
+    expect(gatsbyUtilsMocks.reporter.verbose).toBeCalledTimes(2);
     // gatsby-plugin-image -> generateImageData should be called for both
     expect(generateImageData).toHaveBeenNthCalledWith(2, {
       filename: 'cloud-name>>>public-id',
@@ -207,7 +207,7 @@ describe('resolveCloudinaryAssetData', () => {
       jest.clearAllMocks();
     });
 
-    it('calls reporter.warn and returns null', async () => {
+    it('calls reporter.warn on invalid metadata and returns null', async () => {
       const args = {};
       const result = await resolveCloudinaryAssetData(
         sourceWithoutMeta,
@@ -217,7 +217,7 @@ describe('resolveCloudinaryAssetData', () => {
       );
       expect(getAssetMetadata).toBeCalledTimes(1);
       expect(generateImageData).toBeCalledTimes(0);
-      expect(gatsbyUtilsMocks.reporter.warn).toBeCalledTimes(1);
+      expect(gatsbyUtilsMocks.reporter.warn).toBeCalledTimes(2);
       expect(result).toBe(null);
     });
   });
@@ -231,7 +231,7 @@ describe('resolveCloudinaryAssetData', () => {
       jest.clearAllMocks();
     });
 
-    it('calls reporter.warn and returns null', async () => {
+    it('calls reporter.warn on undefined metadata and returns null', async () => {
       const args = {};
       const result = await resolveCloudinaryAssetData(
         sourceWithoutMeta,
@@ -241,7 +241,7 @@ describe('resolveCloudinaryAssetData', () => {
       );
       expect(getAssetMetadata).toBeCalledTimes(1);
       expect(generateImageData).toBeCalledTimes(0);
-      expect(gatsbyUtilsMocks.reporter.warn).toBeCalledTimes(1);
+      expect(gatsbyUtilsMocks.reporter.warn).toBeCalledTimes(2);
       expect(result).toBe(null);
     });
   });
@@ -274,7 +274,7 @@ describe('resolveCloudinaryAssetData', () => {
       );
       expect(getAssetMetadata).toBeCalledTimes(1);
       expect(generateImageData).toBeCalledTimes(0);
-      expect(gatsbyUtilsMocks.reporter.warn).toBeCalledTimes(1);
+      expect(gatsbyUtilsMocks.reporter.warn).toBeCalledTimes(2);
       expect(result).toBe(null);
     });
 

--- a/plugin/gatsby-plugin-image/resolve-asset.test.js
+++ b/plugin/gatsby-plugin-image/resolve-asset.test.js
@@ -179,7 +179,7 @@ describe('resolveCloudinaryAssetData', () => {
   });
 
   describe('when missing required data', () => {
-    it('calls reporter.warn and returns null', async () => {
+    it('calls reporter.verbose and returns null', async () => {
       const source = {};
       const args = {};
       const result = await resolveCloudinaryAssetData(
@@ -189,7 +189,25 @@ describe('resolveCloudinaryAssetData', () => {
         info
       );
       expect(generateImageData).toBeCalledTimes(0);
-      expect(gatsbyUtilsMocks.reporter.warn).toBeCalledTimes(1);
+      expect(gatsbyUtilsMocks.reporter.verbose).toBeCalledTimes(2);
+      expect(result).toBe(null);
+    });
+  });
+
+  describe('when missing some required data', () => {
+    it('calls reporter.warn and returns null', async () => {
+      const source = {
+        publicId: 'publicId',
+      };
+      const args = {};
+      const result = await resolveCloudinaryAssetData(
+        source,
+        args,
+        context,
+        info
+      );
+      expect(generateImageData).toBeCalledTimes(0);
+      expect(gatsbyUtilsMocks.reporter.warn).toBeCalledTimes(2);
       expect(result).toBe(null);
     });
   });

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -20,7 +20,8 @@
     "axios": "~1.1.3",
     "cloudinary": "^1.33.0",
     "fast-json-stable-stringify": "2.1.0",
-    "gatsby-plugin-utils": "^4.0.0"
+    "gatsby-plugin-utils": "^4.0.0",
+    "probe-image-size": "7.2.3"
   },
   "scripts": {
     "postversion": "cp ../README.md ./README.md && cp ../CHANGELOG.md ./CHANGELOG.md"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4853,7 +4853,7 @@ dateformat@^3.0.0:
   resolved "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz"
   integrity sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==
 
-debug@2.6.9, debug@^2.6.0, debug@^2.6.9:
+debug@2, debug@2.6.9, debug@^2.6.0, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz"
   integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
@@ -4867,7 +4867,7 @@ debug@4, debug@^4.0.0, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, d
   dependencies:
     ms "2.1.2"
 
-debug@^3.0.0, debug@^3.0.1, debug@^3.1.0, debug@^3.2.7:
+debug@^3.0.0, debug@^3.0.1, debug@^3.1.0, debug@^3.2.6, debug@^3.2.7:
   version "3.2.7"
   resolved "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz"
   integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
@@ -7107,7 +7107,7 @@ humanize-ms@^1.2.1:
   dependencies:
     ms "^2.0.0"
 
-iconv-lite@0.4.24, iconv-lite@^0.4.24:
+iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@^0.4.4:
   version "0.4.24"
   resolved "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
@@ -9105,6 +9105,15 @@ natural-compare@^1.4.0:
   resolved "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
+needle@^2.5.2:
+  version "2.9.1"
+  resolved "https://registry.yarnpkg.com/needle/-/needle-2.9.1.tgz#22d1dffbe3490c2b83e301f7709b6736cd8f2684"
+  integrity sha512-6R9fqJ5Zcmf+uYaFgdIHmLwNldn5HbK8L5ybn7Uz+ylX/rnOsSp1AHcvQSrCaFN+qNM1wpymHqD7mVasEOlHGQ==
+  dependencies:
+    debug "^3.2.6"
+    iconv-lite "^0.4.4"
+    sax "^1.2.4"
+
 negotiator@0.6.3, negotiator@^0.6.3, negotiator@~0.6.2:
   version "0.6.3"
   resolved "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz"
@@ -10377,6 +10386,15 @@ pretty-format@^29.3.1:
     ansi-styles "^5.0.0"
     react-is "^18.0.0"
 
+probe-image-size@7.2.3:
+  version "7.2.3"
+  resolved "https://registry.yarnpkg.com/probe-image-size/-/probe-image-size-7.2.3.tgz#d49c64be540ec8edea538f6f585f65a9b3ab4309"
+  integrity sha512-HubhG4Rb2UH8YtV4ba0Vp5bQ7L78RTONYu/ujmCu5nBI8wGv24s4E9xSKBi0N1MowRpxk76pFCpJtW0KPzOK0w==
+  dependencies:
+    lodash.merge "^4.6.2"
+    needle "^2.5.2"
+    stream-parser "~0.3.1"
+
 proc-log@^2.0.0, proc-log@^2.0.1:
   version "2.0.1"
   resolved "https://registry.npmjs.org/proc-log/-/proc-log-2.0.1.tgz"
@@ -11089,6 +11107,11 @@ safe-regex-test@^1.0.0:
   resolved "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
+sax@^1.2.4:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
+  integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
+
 scheduler@^0.23.0:
   version "0.23.0"
   resolved "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz"
@@ -11626,6 +11649,13 @@ stream-combiner2@~1.1.1:
   dependencies:
     duplexer2 "~0.1.0"
     readable-stream "^2.0.2"
+
+stream-parser@~0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/stream-parser/-/stream-parser-0.3.1.tgz#1618548694420021a1182ff0af1911c129761773"
+  integrity sha512-bJ/HgKq41nlKvlhccD5kaCr/P+Hu0wPNKPJOH7en+YrJu/9EgqUF+88w5Jb6KNcjOFMhfX4B2asfeAtIGuHObQ==
+  dependencies:
+    debug "2"
 
 streamsearch@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
Uses `probe-image-size` to fetch metadata when its missing, instead of the Cloudinary `getinfo` flag.

Removes the errors reported in #223, but will still not adhere to the `cloudinaryAssetData` flag.